### PR TITLE
Fix Python 3.12 plugin package loading

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,63 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: ch3n2k/private
+
+jobs:
+  docker:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ch3n2k
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=moinmoin3,enable={{is_default_branch}}
+            type=sha,prefix=moinmoin3-
+            type=ref,event=pr,prefix=moinmoin3-pr-
+
+      - name: Build and publish
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          pull: true
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3-dev python3-pip python3-setuptools ca-certificates uwsgi python3-gevent uwsgi-plugin-gevent-python3 uwsgi-plugin-python3 texlive-latex-base dvipng git locales python-is-python3 \
@@ -6,22 +6,17 @@ RUN apt-get update \
 
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-
-
-RUN pip install -U poetry 
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR /app
 
 COPY . /app/
 
-RUN poetry config virtualenvs.create false && poetry lock && poetry install -n 
-
+RUN pip install --break-system-packages .
 
 WORKDIR /data
 
 
 CMD ["/usr/bin/uwsgi", "--ini", "/data/uwsgi.ini"]
-

--- a/MoinMoin/config/multiconfig.py
+++ b/MoinMoin/config/multiconfig.py
@@ -637,34 +637,56 @@ also the spelling of the directory name.
         import all plugin modules
 
         To be able to import plugin from arbitrary path, we have to load
-        the base package once using imp.load_module. Later, we can use
+        the base package once using importlib. Later, we can use
         standard __import__ call to load plugins in this package.
 
         Since each configured plugin path has unique plugins, we load the
         plugin packages as "moin_plugin_<sha1(path)>.plugin".
         """
+        import _imp
+        import importlib.util
 
         plugin_dirs = [self.plugin_dir] + self.plugin_dirs
         self._plugin_modules = []
-        import importlib.util
 
         try:
             # Lock other threads while we check and import
-            for pdir in plugin_dirs:
-                csum = 'p_%s' % hashlib.new('sha1', pdir.encode("utf8")).hexdigest()
-                modname = '%s.%s' % (self.siteid, csum)
-                # If the module is not loaded, try to load it
-                if modname not in sys.modules:
-                    # Find module on disk and try to load - slow!
-                    abspath = os.path.abspath(pdir) + ".py"
-                    spec = importlib.util.spec_from_file_location(modname, abspath)
-                    if spec is None:
-                        raise ImportError
-                    # Load the module and set in sys.modules
-                    module = importlib.util.module_from_spec(spec)
-                    setattr(sys.modules[self.siteid], 'csum', module)
-                if modname not in self._plugin_modules:
-                    self._plugin_modules.append(modname)
+            _imp.acquire_lock()
+            try:
+                for pdir in plugin_dirs:
+                    csum = 'p_%s' % hashlib.new('sha1', pdir.encode("utf8")).hexdigest()
+                    modname = '%s.%s' % (self.siteid, csum)
+                    # If the module is not loaded, try to load it
+                    if modname not in sys.modules:
+                        # Find the package on disk and try to load it - slow!
+                        package_dir = os.path.abspath(pdir)
+                        package_init = os.path.join(package_dir, '__init__.py')
+                        if not os.path.isfile(package_init):
+                            raise ImportError('No plugin package at %s' % package_dir)
+                        spec = importlib.util.spec_from_file_location(
+                            modname,
+                            package_init,
+                            submodule_search_locations=[package_dir],
+                        )
+                        if spec is None or spec.loader is None:
+                            raise ImportError('Could not create a module spec for %s' % package_dir)
+
+                        module = importlib.util.module_from_spec(spec)
+                        site_module = sys.modules.get(self.siteid)
+                        sys.modules[modname] = module
+                        try:
+                            if site_module is not None:
+                                setattr(site_module, csum, module)
+                            spec.loader.exec_module(module)
+                        except BaseException:
+                            sys.modules.pop(modname, None)
+                            if site_module is not None and getattr(site_module, csum, None) is module:
+                                delattr(site_module, csum)
+                            raise
+                    if modname not in self._plugin_modules:
+                        self._plugin_modules.append(modname)
+            finally:
+                _imp.release_lock()
         except ImportError as err:
             msg = """
 Could not import plugin package "%(path)s" because of ImportError:

--- a/tests/config/_tests/test_multiconfig.py
+++ b/tests/config/_tests/test_multiconfig.py
@@ -7,7 +7,18 @@
 """
 
 
+import os
+import sys
+
 import pytest
+
+
+def test_plugin_package_is_registered(req):
+    module_name = req.cfg._plugin_modules[0]
+    module = sys.modules[module_name]
+
+    assert module.__name__ == module_name
+    assert module.__path__ == [os.path.abspath(req.cfg.plugin_dir)]
 
 
 class TestPasswordChecker:
@@ -37,4 +48,3 @@ class TestPasswordChecker:
                 assert result == (pw_error is None)
 
 coverage_modules = ['MoinMoin.config.multiconfig']
-


### PR DESCRIPTION
## What changed

- load wiki plugin directories as real packages from `plugin/__init__.py`
- register and execute package modules with `importlib`, with rollback on failure
- restore import locking and bind the generated package name correctly
- add a regression test for package registration and search paths
- make the Dockerfile reproduce the existing Ubuntu 24.04 / Python 3.12 image and install the local source without regenerating the lockfile
- build Docker images for pull requests and publish `ch3n2k/private:moinmoin3` plus SHA tags from `master`

## Root cause

The Python 3.12 migration replaced `imp.load_module()` with `module_from_spec()`, but pointed the spec at a nonexistent `plugin.py`, did not register the generated module in `sys.modules`, and did not execute its loader. Later imports such as `wikiconfig.p_<sha1>.action` therefore failed with `'wikiconfig' is not a package` and returned HTTP 500.

## Validation

- `python3 -m py_compile MoinMoin/config/multiconfig.py tests/config/_tests/test_multiconfig.py`
- `git diff --check`
- Python 3.12 image: `pytest -q tests/config/_tests/test_multiconfig.py tests/util/_tests/test_pysupport.py` (7 passed)
- Docker image build from the updated Dockerfile
- `actionlint` for `.github/workflows/docker-publish.yml`
