### PR TITLE
Publish public py3moin Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: ch3n2k/private
+  IMAGE_NAME: ch3n2k/py3moin
 
 jobs:
   docker:
@@ -46,9 +46,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=moinmoin3,enable={{is_default_branch}}
-            type=sha,prefix=moinmoin3-
-            type=ref,event=pr,prefix=moinmoin3-pr-
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+            type=ref,event=pr,prefix=pr-
 
       - name: Build and publish
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## What changed

- publish Docker images to the public `ch3n2k/py3moin` repository
- publish the default branch as `latest`
- retain immutable `sha-<commit>` tags for rollback
- use `pr-<number>` metadata for pull request builds without pushing them

## Impact

After this merges, pushes to `master` publish:

- `ch3n2k/py3moin:latest`
- `ch3n2k/py3moin:sha-<commit>`

Pull requests continue to build without logging in to Docker Hub or publishing images.

## Validation

- Ruby YAML parser
- `actionlint`
- `git diff --check`
