### PR TITLE
Merge latest upstream moin-1.9 changes

### DIFF
--- a/MoinMoin/action/diff.py
+++ b/MoinMoin/action/diff.py
@@ -164,9 +164,6 @@ def execute(pagename, request):
 """ % {'button': other_diff_button_html}
 
     prev_oldrev = (oldrev > 1) and (oldrev - 1) or 1
-    next_oldrev = (oldrev < currentrev) and (oldrev + 1) or currentrev
-
-    prev_newrev = (newrev > 1) and (newrev - 1) or 1
     next_newrev = (newrev < currentrev) and (newrev + 1) or currentrev
 
     navigation_html = navigation_html % (title,
@@ -176,22 +173,20 @@ def execute(pagename, request):
 
     request.write(f.rawHTML(navigation_html))
 
-    def rev_nav_link(enabled, old_rev, new_rev, caption, css_classes, enabled_title, disabled_title):
-        if enabled:
-            return currentpage.link_to(request, on=1, querystr={
-                    'action': 'diff',
-                    'rev1': old_rev,
-                    'rev2': new_rev,
-                    }, css_class="diff-nav-link %s" % css_classes, title=enabled_title) + request.formatter.text(caption) + currentpage.link_to(request, on=0)
-        else:
-            return '<span class="diff-no-nav-link %(css_classes)s" title="%(disabled_title)s">%(caption)s</span>' % {
-                'css_classes': css_classes,
-                'disabled_title': disabled_title,
-                'caption': caption,
-                }
+    # Note: there used to be a per-pane navigation of <= < > >= links here,
+    # moving rev1 and rev2 independently. As both sides could be moved on
+    # their own, following those links reached every (rev1, rev2) combination,
+    # which is rev_count*(rev_count-1)/2 distinct urls for a single page - and
+    # each of them renders two revisions plus (for fancy diffs) the whole page
+    # below the diff. Crawlers ignore rel=nofollow and walked all of them.
+    # The same diffs are still available without offering that many urls:
+    # the "Previous change" / "Next change" buttons above step through the
+    # revisions, and the info action has a radio button per revision to
+    # compare any two of them. Both are GET forms, so they cost us nothing
+    # unless somebody actually clicks.
 
     rev_info_html = """
-  <div class="diff-info diff-info-header">%%(rev_first_link)s %%(rev_prev_link)s %(rev_header)s %%(rev_next_link)s %%(rev_last_link)s</div>
+  <div class="diff-info diff-info-header">%(rev_header)s</div>
   <div class="diff-info diff-info-rev-size"><span class="diff-info-caption">%(rev_size_caption)s:</span> <span class="diff-info-value">%%(rev_size)d</span></div>
   <div class="diff-info diff-info-rev-author"><span class="diff-info-caption">%(rev_author_caption)s:</span> <span class="diff-info-value">%%(rev_author)s</span></div>
   <div class="diff-info diff-info-rev-comment"><span class="diff-info-caption">%(rev_comment_caption)s:</span> <span class="diff-info-value">%%(rev_comment)s</span></div>
@@ -204,10 +199,6 @@ def execute(pagename, request):
 }
 
     rev_info_old_html = rev_info_html % {
-        'rev_first_link': rev_nav_link(oldrev > 1, 1, newrev, u'\u21e4', 'diff-first-link diff-old-rev', _('Diff with oldest revision in left pane'), _("No older revision available for diff")),
-        'rev_prev_link': rev_nav_link(oldrev > 1, prev_oldrev, newrev, u'\u2190', 'diff-prev-link diff-old-rev', _('Diff with older revision in left pane'), _("No older revision available for diff")),
-        'rev_next_link': rev_nav_link((oldrev < currentrev) and (next_oldrev < newrev), next_oldrev, newrev, u'\u2192', 'diff-next-link diff-old-rev', _('Diff with newer revision in left pane'), _("Can't change to revision newer than in right pane")),
-        'rev_last_link': '',
         'rev': oldrev,
         'rev_size': oldpage.size(),
         'rev_author': oldlog.getEditor(request) or _('N/A'),
@@ -216,10 +207,6 @@ def execute(pagename, request):
     }
 
     rev_info_new_html = rev_info_html % {
-        'rev_first_link': '',
-        'rev_prev_link': rev_nav_link((newrev > 1) and (oldrev < prev_newrev), oldrev, prev_newrev, u'\u2190', 'diff-prev-link diff-new-rev', _('Diff with older revision in right pane'), _("Can't change to revision older than revision in left pane")),
-        'rev_next_link': rev_nav_link(newrev < currentrev, oldrev, next_newrev, u'\u2192', 'diff-next-link diff-new-rev', _('Diff with newer revision in right pane'), _("No newer revision available for diff")),
-        'rev_last_link': rev_nav_link(newrev < currentrev, oldrev, currentrev, u'\u21e5', 'diff-last-link diff-old-rev', _('Diff with newest revision in right pane'), _("No newer revision available for diff")),
         'rev': newrev,
         'rev_size': newpage.size(),
         'rev_author': newlog.getEditor(request) or _('N/A'),

--- a/MoinMoin/action/info.py
+++ b/MoinMoin/action/info.py
@@ -184,35 +184,32 @@ def execute(pagename, request):
             max_count_html = []
             cur_count_added = False
 
-
             for count in max_count_possibilities:
                 # max count value can be not in list of predefined values
                 if max_count <= count and not cur_count_added:
-                    max_count_html.append("".join([
-                        f.span(1, css_class="info-count-item info-cur-count"),
-                        f.text(str(max_count)),
-                        f.span(0),
-                    ]))
+                    max_count_html.append('<option value="%d" selected="selected">%d</option>'
+                                          % (max_count, max_count))
                     cur_count_added = True
 
                 # checking for limit_max_count to prevent showing unavailable options
                 if max_count != count and count <= limit_max_count:
-                    max_count_html.append("".join([
-                        f.span(1, css_class="info-count-item"),
-                        page.link_to(request, on=1, querystr={
-                            'action': 'info',
-                            'offset': str(offset),
-                            'max_count': str(count),
-                            }, css_class="info-count-link", rel="nofollow"),
-                        f.text(str(count)),
-                        page.link_to(request, on=0),
-                        f.span(0),
-                    ]))
+                    max_count_html.append('<option value="%d">%d</option>' % (count, count))
 
+            # This used to be one link per possible count, which gave a crawler
+            # an url per (offset, count) combination. It is a select of the form
+            # around the history table now - the same select-and-press-Do that
+            # the theme uses for its actions menu - so it costs nothing until
+            # somebody actually uses it. The offset has to be carried along, as
+            # it was by those links.
             count_select_html += "".join([
                 f.span(1, css_class="info-count-selector"),
                     f.text(" ("),
-                    f.text(_("%s items per page")) % (f.span(1, css_class="info-count-selector info-count-selector-divider") + f.text(" | ") + f.span(0)).join(max_count_html),
+                    f.text(_("%s items per page")) % (
+                        '<input type="hidden" name="offset" value="%d">'
+                        '<select name="max_count" class="info-count-select">%s</select>'
+                        % (offset, "".join(max_count_html))),
+                    f.rawHTML(' <button type="submit" name="action" value="info">%s</button>'
+                              % wikiutil.escape(_("Do"))),
                     f.text(")"),
                 f.span(0),
             ])

--- a/MoinMoin/action/info.py
+++ b/MoinMoin/action/info.py
@@ -103,78 +103,41 @@ def execute(pagename, request):
                 offset = 0
             offset = max(min(offset, log_size - 1), 0)
 
+            # The Newer / Older buttons say which way to move, the offset they
+            # move from comes from the form they are in (see paging_nav_html
+            # below). Moving is done here so that everything after this - the
+            # "showing entries from ... to ..." line, the buttons and the rows
+            # of the listing - sees the offset that is actually shown.
+            offsetmove = request.values.get('offsetmove', u'')
+            if offsetmove == u'newer':
+                offset = ((offset - 1) / max_count) * max_count
+            elif offsetmove == u'older':
+                offset = ((offset + max_count) / max_count) * max_count
+            offset = max(min(offset, log_size - 1), 0)
+
             paging_info_html += f.paragraph(1, css_class="searchstats info-paging-info") + _("Showing page edit history entries from '''%(start_offset)d''' to '''%(end_offset)d''' out of '''%(total_count)d''' entries total.", wiki=True) % {
                 'start_offset': log_size - min(log_size, offset + max_count) + 1,
                 'end_offset': log_size - offset,
                 'total_count': log_size,
             } + f.paragraph(0)
 
-            # generating offset navigating links
+            # generating offset navigation
             if max_count < log_size or offset != 0:
-                offset_links = []
-                cur_offset = max_count
-                near_count = 5 # request.cfg.pagination_size
+                # This used to be a row of links: "Newer", "Older", the first
+                # and the last page of the log and the numbered pages around
+                # the current one. That is an url per page of the listing, and
+                # crawlers walked all of them. Two buttons reach the same
+                # places, one page at a time - they only say which way to go,
+                # the offset they move from is in the form around them.
+                def offset_button(direction, caption, enabled):
+                    return '<button type="submit" name="offsetmove" value="%s"%s>%s</button> ' % (
+                        direction,
+                        not enabled and ' disabled="disabled"' or '',
+                        wikiutil.escape(caption))
 
-                min_offset = max(0, (offset + max_count - 1) / max_count - near_count)
-                max_offset = min((log_size - 1) / max_count, offset / max_count + near_count)
-                offset_added = False
-
-                def add_offset_link(offset, caption=None):
-                    offset_links.append(f.table_cell(1, css_class="info-offset-item") +
-                        page.link_to(request, on=1, querystr={
-                            'action': 'info',
-                            'offset': str(offset),
-                            'max_count': str(max_count),
-                            }, css_class="info-offset-nav-link", rel="nofollow") + f.text(caption or str(log_size - offset)) + page.link_to(request, on=0) +
-                        f.table_cell(0)
-                    )
-
-                # link to previous page - only if not at start
-                if offset > 0:
-                    add_offset_link(((offset - 1) / max_count) * max_count, _("Newer"))
-
-                # link to beggining of event log - if min_offset is not minimal
-                if min_offset > 0:
-                    add_offset_link(0)
-                    # adding gap only if min_offset not explicitly following beginning
-                    if min_offset > 1:
-                        offset_links.append(f.table_cell(1, css_class="info-offset-gap") + f.text(u'\u2026') + f.table_cell(0))
-
-                # generating near pages links
-                for cur_offset in range(min_offset, max_offset + 1):
-                    # note that current offset may be not multiple of max_count,
-                    # so we check whether we should add current offset marker like this
-                    if not offset_added and offset <= cur_offset * max_count:
-                        # current info history view offset
-                        offset_links.append(f.table_cell(1, css_class="info-offset-item info-cur-offset") + f.text(str(log_size - offset)) + f.table_cell(0))
-                        offset_added = True
-
-                    # add link, if not at this offset
-                    if offset != cur_offset * max_count:
-                        add_offset_link(cur_offset * max_count)
-
-                # link to the last page of event log
-                if max_offset < (log_size - 1) / max_count:
-                    if max_offset < (log_size - 1) / max_count - 1:
-                        offset_links.append(f.table_cell(1, css_class="info-offset-gap") + f.text(u'\u2026') + f.table_cell(0))
-                    add_offset_link(((log_size - 1) / max_count) * max_count)
-
-                # special case - if offset is greater than max_offset * max_count
-                if offset > max_offset * max_count:
-                    offset_links.append(f.table_cell(1, css_class="info-offset-item info-cur-offset") + f.text(str(log_size - offset)) + f.table_cell(0))
-
-                # link to next page
-                if offset < (log_size - max_count):
-                    add_offset_link(((offset + max_count) / max_count) * max_count, _("Older"))
-
-                # generating html
-                paging_nav_html += "".join([
-                    f.table(1, css_class="searchpages"),
-                    f.table_row(1),
-                    "".join(offset_links),
-                    f.table_row(0),
-                    f.table(0),
-                ])
+                paging_nav_html += (
+                    offset_button('newer', _("Newer"), offset > 0) +
+                    offset_button('older', _("Older"), offset < (log_size - max_count)))
 
         # generating max_count switcher
         # we do it only in case history_count has additional values
@@ -196,20 +159,18 @@ def execute(pagename, request):
                     max_count_html.append('<option value="%d">%d</option>' % (count, count))
 
             # This used to be one link per possible count, which gave a crawler
-            # an url per (offset, count) combination. It is a select of the form
-            # around the history table now - the same select-and-press-Do that
-            # the theme uses for its actions menu - so it costs nothing until
-            # somebody actually uses it. The offset has to be carried along, as
-            # it was by those links.
+            # an url per (offset, count) combination. It is a select of the
+            # paging form now - the same select-and-press-Do that the theme
+            # uses for its actions menu - so it costs nothing until somebody
+            # actually uses it. That form carries the action and the offset,
+            # so this button needs no name of its own.
             count_select_html += "".join([
                 f.span(1, css_class="info-count-selector"),
                     f.text(" ("),
                     f.text(_("%s items per page")) % (
-                        '<input type="hidden" name="offset" value="%d">'
                         '<select name="max_count" class="info-count-select">%s</select>'
-                        % (offset, "".join(max_count_html))),
-                    f.rawHTML(' <button type="submit" name="action" value="info">%s</button>'
-                              % wikiutil.escape(_("Do"))),
+                        % "".join(max_count_html)),
+                    f.rawHTML(' <button type="submit">%s</button>' % wikiutil.escape(_("Do"))),
                     f.text(")"),
                 f.span(0),
             ])
@@ -330,22 +291,41 @@ def execute(pagename, request):
         div = html.DIV(id="page-history")
         div.append(history_table.render(method="GET"))
 
-        form = html.FORM(method="GET", action="")
-        if paging:
-            form.append(f.div(1, css_class="info-paging-info") + paging_info_html + count_select_html + f.div(0))
-            form.append("".join([
-                f.div(1, css_class="info-paging-nav info-paging-nav-top"),
-                paging_nav_html,
+        # The paging controls are a form of their own, next to (not inside) the
+        # one around the history table: that one can not have a fixed action,
+        # its buttons each bring their own, while these all mean action=info.
+        # So a hidden input can carry it here, which leaves the buttons free to
+        # say what they do - pick a count, or move a page.
+        def paging_form(css_class, content, hidden_max_count=False):
+            return "".join([
+                '<form method="GET" action="">',
+                f.div(1, css_class=css_class),
+                '<input type="hidden" name="action" value="info">',
+                '<input type="hidden" name="offset" value="%d">' % offset,
+                hidden_max_count and '<input type="hidden" name="max_count" value="%d">' % max_count or '',
+                content,
                 f.div(0),
-            ]))
-        form.append(div)
+                '</form>',
+            ])
+
         if paging:
-            form.append("".join([
-                f.div(1, css_class="info-paging-nav info-paging-nav-bottom"),
-                paging_nav_html,
-                f.div(0)
-            ]))
-        request.write(unicode(form))
+            request.write(paging_form("info-paging-info",
+                                      paging_info_html + count_select_html + paging_nav_html))
+
+        # The table brings its own form - that is what render(method="GET")
+        # does - and the radio buttons and the two column header buttons are
+        # inside it. There used to be another form around it here, holding the
+        # hidden action=diff; now that those buttons carry their action
+        # themselves, that outer form would only be a form nested in a form,
+        # which is not allowed and which browsers resolve by dropping the
+        # inner start tag, so that the inner </form> ends the outer one.
+        request.write(unicode(div))
+
+        if paging:
+            # down here the count select is out of reach, so the count the
+            # buttons move within has to be carried along
+            request.write(paging_form("info-paging-nav info-paging-nav-bottom",
+                                      paging_nav_html, hidden_max_count=True))
 
     # main function
     _ = request.getText

--- a/MoinMoin/action/info.py
+++ b/MoinMoin/action/info.py
@@ -225,24 +225,30 @@ def execute(pagename, request):
             Column('rev', label='#', align='right'),
             Column('mtime', label=_('Date'), align='right'),
             Column('size', label=_('Size'), align='right'),
-            Column('diff', label='<input type="submit" value="%s">' % (_("Diff"))),
+            # both column headers submit the one form around the table, the
+            # pressed button decides which action the form runs
+            Column('diff', label='<button type="submit" name="action" value="diff">%s</button>' % (_("Diff"))),
             Column('editor', label=_('Editor'), hidden=not request.cfg.show_names),
             Column('comment', label=_('Comment')),
-            Column('action', label=_('Action')),
+            Column('action', label='<button type="submit" name="action" value="info">%s</button>' % (_("Do"))),
             ]
 
         # generate history list
 
-        def render_action(text, query, **kw):
-            kw.update(dict(rel='nofollow'))
-            return page.link_to(request, text, querystr=query, **kw)
+        # The actions of a row used to be links, which gave a crawler one url
+        # per revision and per attachment, each of them rendering a complete
+        # page. They are radio buttons of a single group now: picking one and
+        # pressing the button in the column header runs it, and crawlers do not
+        # submit forms. See the rowaction handling in execute() below.
+        def render_action(text, value):
+            return '<input type="radio" name="rowaction" value="%s">%s' % (
+                wikiutil.escape(value, True), wikiutil.escape(text))
 
-        def render_file_action(text, pagename, filename, request, do):
-            url = AttachFile.getAttachUrl(pagename, filename, request, do=do)
-            if url:
-                f = request.formatter
-                link = f.url(1, url) + f.text(text) + f.url(0)
-                return link
+        def render_file_action(text, filename, do):
+            # do not offer what this file has no handler for (as before: the
+            # link was left out when getAttachUrl() had nothing to point to)
+            if AttachFile.get_action(request, filename, do):
+                return render_action(text, u'AttachFile:%s:%s' % (do, filename))
 
         may_write = request.user.may.write(pagename)
         may_delete = request.user.may.delete(pagename)
@@ -259,7 +265,7 @@ def execute(pagename, request):
             actions = []
             if line.action in ('SAVE', 'SAVENEW', 'SAVE/REVERT', 'SAVE/RENAME', ):
                 size = page.size(rev=rev)
-                actions.append(render_action(_('view'), {'action': 'recall', 'rev': '%d' % rev}))
+                actions.append(render_action(_('view'), u'recall:%d' % rev))
                 if pgactioncount == 0:
                     rchecked = ' checked="checked"'
                     lchecked = ''
@@ -291,12 +297,12 @@ def execute(pagename, request):
                 comment = "%s: %s %s" % (line.action, filename, line.comment)
                 if AttachFile.exists(request, pagename, filename):
                     size = AttachFile.size(request, pagename, filename)
-                    actions.append(render_file_action(_('view'), pagename, filename, request, do='view'))
-                    actions.append(render_file_action(_('get'), pagename, filename, request, do='get'))
+                    actions.append(render_file_action(_('view'), filename, 'view'))
+                    actions.append(render_file_action(_('get'), filename, 'get'))
                     if may_delete:
-                        actions.append(render_file_action(_('del'), pagename, filename, request, do='del'))
+                        actions.append(render_file_action(_('del'), filename, 'del'))
                     if may_write:
-                        actions.append(render_file_action(_('edit'), pagename, filename, request, do='modify'))
+                        actions.append(render_file_action(_('edit'), filename, 'modify'))
                 else:
                     size = 0
 
@@ -325,7 +331,6 @@ def execute(pagename, request):
         history_table.setData(history)
 
         div = html.DIV(id="page-history")
-        div.append(html.INPUT(type="hidden", name="action", value="diff"))
         div.append(history_table.render(method="GET"))
 
         form = html.FORM(method="GET", action="")
@@ -348,6 +353,26 @@ def execute(pagename, request):
     # main function
     _ = request.getText
     page = Page(request, pagename)
+
+    # A row action was selected in the history and the form was submitted (see
+    # render_action() above): send the browser to the action it stands for.
+    # The url is built here from a fixed set of actions, the submitted value
+    # only selects one of them and gives its target, so this can not be used to
+    # send anybody somewhere else. The actions check their own permissions, as
+    # they did when these were links.
+    rowaction = request.values.get('rowaction', u'')
+    if rowaction:
+        what = rowaction.split(u':', 2)
+        url = None
+        if len(what) == 2 and what[0] == u'recall' and what[1].isdigit():
+            url = page.url(request, querystr={'action': 'recall', 'rev': str(int(what[1]))})
+        elif len(what) == 3 and what[0] == u'AttachFile' and what[1] in ('view', 'get', 'del', 'modify'):
+            # getAttachUrl() creates the ticket the destructive ones need
+            url = AttachFile.getAttachUrl(pagename, what[2], request, do=what[1])
+        if url:
+            request.http_redirect(url)
+            return
+
     title = page.split_title()
 
     request.setContentLanguage(request.lang)

--- a/MoinMoin/action/info.py
+++ b/MoinMoin/action/info.py
@@ -310,7 +310,7 @@ def execute(pagename, request):
 
         if paging:
             request.write(paging_form("info-paging-info",
-                                      paging_info_html + count_select_html + paging_nav_html))
+                                      paging_info_html + count_select_html))
 
         # The table brings its own form - that is what render(method="GET")
         # does - and the radio buttons and the two column header buttons are

--- a/MoinMoin/action/info.py
+++ b/MoinMoin/action/info.py
@@ -268,9 +268,14 @@ def execute(pagename, request):
                     rchecked = ''
                 else:
                     lchecked = rchecked = ''
+                # Note: there used to be a "to previous" diff link per row here.
+                # Those links were the diff urls a crawler picked up from this
+                # page - one per revision, each of them rendering two revisions
+                # and (for fancy diffs) the whole page below the diff. The radio
+                # buttons in this same column do that and more, they compare any
+                # two of the listed revisions, and being a GET form they are not
+                # followed by crawlers.
                 diff = '<input type="radio" name="rev1" value="%d"%s><input type="radio" name="rev2" value="%d"%s>' % (rev, lchecked, rev, rchecked)
-                if rev > 1:
-                    diff += render_action(' ' + _('to previous'), {'action': 'diff', 'rev1': rev-1, 'rev2': rev})
                 comment = line.comment
                 if not comment:
                     if '/REVERT' in line.action:

--- a/MoinMoin/action/info.py
+++ b/MoinMoin/action/info.py
@@ -379,19 +379,29 @@ def execute(pagename, request):
     f = request.formatter
 
     request.theme.send_title(_('Info for "%s"') % (title, ), page=page)
+    # (label, name of the parameter that selects this view - the revision
+    # history is what info shows when neither of the others is asked for)
     menu_items = [
-        (_('Show "%(title)s"') % {'title': _('Revision History')},
-         {'action': 'info'}),
-        (_('Show "%(title)s"') % {'title': _('General Page Infos')},
-         {'action': 'info', 'general': '1'}),
-        (_('Show "%(title)s"') % {'title': _('Page hits and edits')},
-         {'action': 'info', 'hitcounts': '1'}),
+        (_('Show "%(title)s"') % {'title': _('Revision History')}, None),
+        (_('Show "%(title)s"') % {'title': _('General Page Infos')}, 'general'),
+        (_('Show "%(title)s"') % {'title': _('Page hits and edits')}, 'hitcounts'),
     ]
     request.write(f.div(1, id="content")) # start content div
-    request.write(f.paragraph(1))
-    for text, querystr in menu_items:
-        request.write("[%s] " % page.link_to(request, text=text, querystr=querystr, rel='nofollow'))
-    request.write(f.paragraph(0))
+    # These used to be links, giving a crawler three urls on every page of the
+    # wiki - and the first of them leads on to the whole page history. A GET
+    # form shows the same three views to a reader, and crawlers do not submit
+    # forms. The button that shows the history needs no name of its own, it
+    # just leaves general and hitcounts unset.
+    request.write(f.rawHTML('<form method="GET" action="%s"><div>'
+                            '<input type="hidden" name="action" value="info">'
+                            % wikiutil.escape(page.url(request), True)))
+    for text, name in menu_items:
+        if name:
+            button = '<button type="submit" name="%s" value="1">%s</button> ' % (name, wikiutil.escape(text))
+        else:
+            button = '<button type="submit">%s</button> ' % wikiutil.escape(text)
+        request.write(f.rawHTML(button))
+    request.write(f.rawHTML('</div></form>'))
 
     show_hitcounts = int(request.values.get('hitcounts', 0)) != 0
     show_general = int(request.values.get('general', 0)) != 0

--- a/MoinMoin/action/pollsistersites.py
+++ b/MoinMoin/action/pollsistersites.py
@@ -4,7 +4,7 @@
 
     This action fetches lists of page urls and page names from sister sites,
     so we can implement SisterWiki functionality.
-    See: http://usemod.com/cgi-bin/mb.pl?SisterSitesImplementationGuide
+    See: http://meatballwiki.org/wiki/?SisterSitesImplementationGuide
 
     @copyright: 2007 MoinMoin:ThomasWaldmann
     @license: GNU GPL, see COPYING for details.

--- a/MoinMoin/action/sisterpages.py
+++ b/MoinMoin/action/sisterpages.py
@@ -4,7 +4,7 @@
 
     This action generates a list of page urls and page names, so that other wikis
     can implement SisterWiki functionality easily.
-    See: http://usemod.com/cgi-bin/mb.pl?SisterSitesImplementationGuide
+    See: http://meatballwiki.org/wiki/?SisterSitesImplementationGuide
 
     @copyright: 2007 MoinMoin:ThomasWaldmann
     @license: GNU GPL, see COPYING for details.

--- a/MoinMoin/action/titleindex.py
+++ b/MoinMoin/action/titleindex.py
@@ -3,7 +3,7 @@
     MoinMoin - "titleindex" action
 
     This action generates a plain list of pages, so that other wikis
-    can implement http://www.usemod.com/cgi-bin/mb.pl?MetaWiki more
+    can implement http://meatballwiki.org/wiki/?MetaWiki more
     easily.
 
     @copyright: 2001 Juergen Hermann <jh@web.de>

--- a/MoinMoin/config/multiconfig.py
+++ b/MoinMoin/config/multiconfig.py
@@ -949,7 +949,7 @@ options_no_group_name = {
 
     ('edit_bar', ['Edit', 'Comments', 'Discussion', 'Info', 'Subscribe', 'Quicklink', 'Attachments', 'ActionsMenu'],
      'list of edit bar entries'),
-    ('history_count', (100, 200, 5, 10, 25, 50), "Number of revisions shown for info/history action (default_count_shown, max_count_shown, [other values shown as page size choices]). At least first two values (default and maximum) should be provided. If additional values are provided, user will be able to change number of items per page in the UI."),
+    ('history_count', (25, 200, 5, 10, 50, 100), "Number of revisions shown for info/history action (default_count_shown, max_count_shown, [other values shown as page size choices]). At least first two values (default and maximum) should be provided. If additional values are provided, user will be able to change number of items per page in the UI."),
     ('history_paging', True, "Enable paging functionality for info action's history display."),
 
     ('show_hosts', True,

--- a/MoinMoin/macro/MonthCalendar.py
+++ b/MoinMoin/macro/MonthCalendar.py
@@ -89,6 +89,10 @@
         * added template argument for specifying an edit template for new pages
     * 2.3:
         * adapted to moin 1.7 new macro parameter parsing
+    * 2.4:
+        * limited the range the prev/next navigation can reach, see
+          MAX_NAV_OFFSET below. Without such a limit, the navigation offers an
+          infinite amount of distinct urls and crawlers walk them endlessly.
 
     Usage:
         <<MonthCalendar(BasePage,year,month,monthoffset,monthoffset2,height6,anniversary,template)>>
@@ -161,6 +165,15 @@ from MoinMoin.Page import Page
 # XXX change here ----------------vvvvvv
 calendar.setfirstweekday(calendar.MONDAY)
 
+# How many months the prev/next navigation may move away from the month the
+# macro was configured to show. Beyond that limit the arrows are rendered as
+# plain text instead of links, and an offset given in the url is clamped.
+# This is what keeps the amount of urls this macro generates finite: crawlers
+# ignore rel=nofollow and robots meta tags, but they can not follow a link
+# that is not there.
+# May be overridden in the wiki config as monthcalendar_max_nav_offset.
+MAX_NAV_OFFSET = 18 # 1.5 years
+
 def cliprgb(r, g, b):
     """ clip r,g,b values into range 0..254 """
     def clip(x):
@@ -203,6 +216,14 @@ def parseargs(request, args, defpagename, defyear, defmonth, defoffset, defoffse
 
     return parmpagename, parmyear, parmmonth, parmoffset, parmoffset2, parmheight6, parmanniversary, parmtemplate
 
+def clampoffset(offset, maxoffset):
+    """ clip a navigation offset into range -maxoffset..maxoffset """
+    if offset < -maxoffset:
+        return -maxoffset
+    elif offset > maxoffset:
+        return maxoffset
+    return offset
+
 def execute(macro, text):
     request = macro.request
     formatter = macro.formatter
@@ -236,20 +257,29 @@ def execute(macro, text):
     # calendars on the same page)?
     #if has_calparms and (cparmpagename,cparmyear,cparmmonth,cparmoffset) == (parmpagename,parmyear,parmmonth,parmoffset):
 
+    max_nav_offset = getattr(request.cfg, 'monthcalendar_max_nav_offset', MAX_NAV_OFFSET)
+
     # move all calendars when using the navigation:
     if has_calparms and cparmpagename == parmpagename:
-        year, month = yearmonthplusoffset(parmyear, parmmonth, parmoffset + cparmoffset2)
-        parmoffset2 = cparmoffset2
+        # this offset comes from the url query string, so it is controlled by
+        # whoever requests the page - crawlers included. Clamping it (and the
+        # navigation links built from it below) keeps the amount of distinct
+        # urls of this calendar finite.
+        parmoffset2 = clampoffset(cparmoffset2, max_nav_offset)
+        year, month = yearmonthplusoffset(parmyear, parmmonth, parmoffset + parmoffset2)
         parmtemplate = cparmtemplate
     else:
+        # note: parmoffset2 given as macro argument does not move the displayed
+        # month, it only is the starting point of the navigation.
+        parmoffset2 = clampoffset(parmoffset2, max_nav_offset)
         year, month = yearmonthplusoffset(parmyear, parmmonth, parmoffset)
 
     if request.isSpiderAgent and abs(currentyear - year) > 1:
         return '' # this is a bot and it didn't follow the rules (see below)
     if currentyear == year:
-        attrs = {}
+        navattrs = {}
     else:
-        attrs = {'rel': 'nofollow' } # otherwise even well-behaved bots will index forever
+        navattrs = {'rel': 'nofollow' } # otherwise even well-behaved bots will index forever
 
     # get the calendar
     monthcal = calendar.monthcalendar(year, month)
@@ -269,15 +299,19 @@ def execute(macro, text):
     qpagenames = '*'.join([wikiutil.quoteWikinameURL(pn) for pn in parmpagename])
     qtemplate = wikiutil.quoteWikinameURL(parmtemplate)
     querystr = "calparms=%%s,%d,%d,%d,%%d,,,%%s" % (parmyear, parmmonth, parmoffset)
-    prevlink = p.url(request, querystr % (qpagenames, parmoffset2 - 1, qtemplate))
-    nextlink = p.url(request, querystr % (qpagenames, parmoffset2 + 1, qtemplate))
-    prevylink = p.url(request, querystr % (qpagenames, parmoffset2 - 12, qtemplate))
-    nextylink = p.url(request, querystr % (qpagenames, parmoffset2 + 12, qtemplate))
 
-    prevmonth = formatter.url(1, prevlink, 'cal-link', **attrs) + '&lt;' + formatter.url(0)
-    nextmonth = formatter.url(1, nextlink, 'cal-link', **attrs) + '&gt;' + formatter.url(0)
-    prevyear = formatter.url(1, prevylink, 'cal-link', **attrs) + '&lt;&lt;' + formatter.url(0)
-    nextyear = formatter.url(1, nextylink, 'cal-link', **attrs) + '&gt;&gt;' + formatter.url(0)
+    def navigation(offset, label):
+        """ a navigation link moving the calendar to navigation offset <offset>,
+            or just <label> if that offset is out of the allowed range """
+        if abs(offset) > max_nav_offset:
+            return label
+        url = p.url(request, querystr % (qpagenames, offset, qtemplate))
+        return formatter.url(1, url, 'cal-link', **navattrs) + label + formatter.url(0)
+
+    prevmonth = navigation(parmoffset2 - 1, '&lt;')
+    nextmonth = navigation(parmoffset2 + 1, '&gt;')
+    prevyear = navigation(parmoffset2 - 12, '&lt;&lt;')
+    nextyear = navigation(parmoffset2 + 12, '&gt;&gt;')
 
     if parmpagename != [thispage]:
         pagelinks = ''

--- a/MoinMoin/macro/MonthCalendar.py
+++ b/MoinMoin/macro/MonthCalendar.py
@@ -97,6 +97,9 @@
         * days without a page are only linked if the user may create that page.
           Anonymous visitors (and thus the crawlers) used to get a link per day
           leading to a "page does not exist" view.
+    * 2.6:
+        * the prev/next navigation links always are rel=nofollow now, not just
+          for years other than the current one.
 
     Usage:
         <<MonthCalendar(BasePage,year,month,monthoffset,monthoffset2,height6,anniversary,template)>>
@@ -280,10 +283,11 @@ def execute(macro, text):
 
     if request.isSpiderAgent and abs(currentyear - year) > 1:
         return '' # this is a bot and it didn't follow the rules (see below)
-    if currentyear == year:
-        navattrs = {}
-    else:
-        navattrs = {'rel': 'nofollow' } # otherwise even well-behaved bots will index forever
+    # The navigation is never worth indexing: it shows the same day pages the
+    # calendar already links, just arranged by month. Used to be done only for
+    # years other than the current one, but there is nothing to gain from
+    # letting bots crawl the current year's navigation either.
+    navattrs = {'rel': 'nofollow'}
 
     # get the calendar
     monthcal = calendar.monthcalendar(year, month)

--- a/MoinMoin/macro/MonthCalendar.py
+++ b/MoinMoin/macro/MonthCalendar.py
@@ -93,6 +93,10 @@
         * limited the range the prev/next navigation can reach, see
           MAX_NAV_OFFSET below. Without such a limit, the navigation offers an
           infinite amount of distinct urls and crawlers walk them endlessly.
+    * 2.5:
+        * days without a page are only linked if the user may create that page.
+          Anonymous visitors (and thus the crawlers) used to get a link per day
+          leading to a "page does not exist" view.
 
     Usage:
         <<MonthCalendar(BasePage,year,month,monthoffset,monthoffset2,height6,anniversary,template)>>
@@ -369,6 +373,11 @@ def execute(macro, text):
             monthcal = monthcal + [[0, 0, 0, 0, 0, 0, 0]]
 
     maketip_js = []
+    # May the user create the day pages of this calendar? A page that does not
+    # exist can not carry an acl of its own, so the answer is the same for every
+    # nonexisting day page here and we only compute it for the first one.
+    # None means "not asked yet".
+    may_create = None
     restrn = []
     for week in monthcal:
         restdn = []
@@ -383,7 +392,9 @@ def execute(macro, text):
                 else:
                     link = "%s/%4d-%02d-%02d" % (page, year, month, day)
                 daypage = Page(request, link)
-                if daypage.exists() and request.user.may.read(link):
+                dayexists = daypage.exists()
+                if dayexists and request.user.may.read(link):
+                    linkday = True
                     csslink = "cal-usedday"
                     query = {}
                     r, g, b, u = (255, 0, 0, 1)
@@ -404,6 +415,19 @@ def execute(macro, text):
                     attrs = {'onMouseOver': "tip('%s')" % tipname_unescaped,
                              'onMouseOut': "untip()"}
                 else:
+                    # nothing to show here yet - only link the day if the user
+                    # could actually create that page. For anonymous visitors
+                    # (and that is what the crawlers are) this usually is not
+                    # the case and we save them a page view each that would
+                    # have rendered a "this page does not exist" view.
+                    if dayexists:
+                        # exists, but is not readable by this user: such a page
+                        # can carry an acl of its own, so we have to ask for it
+                        linkday = request.user.may.write(link)
+                    else:
+                        if may_create is None:
+                            may_create = request.user.may.write(link)
+                        linkday = may_create
                     csslink = "cal-emptyday"
                     if parmtemplate:
                         query = {'action': 'edit', 'template': parmtemplate}
@@ -424,7 +448,12 @@ def execute(macro, text):
                             r, g, b = (r, g+colorstep, b)
                 r, g, b = cliprgb(r, g, b)
                 style = 'background-color:#%02x%02x%02x' % (r, g, b)
-                fmtlink = formatter.url(1, daypage.url(request, query), csslink, **attrs) + str(day) + formatter.url(0)
+                if linkday:
+                    fmtlink = formatter.url(1, daypage.url(request, query), csslink, **attrs) + str(day) + formatter.url(0)
+                else:
+                    # same class as the link would have had, so the themes can
+                    # keep styling the day the same way
+                    fmtlink = '<span class="%s">%d</span>' % (csslink, day)
                 if day == currentday and month == currentmonth and year == currentyear:
                     cssday = "cal-today"
                     fmtlink = "<b>%s</b>" % fmtlink # for browser with CSS probs

--- a/MoinMoin/macro/MonthCalendar.py
+++ b/MoinMoin/macro/MonthCalendar.py
@@ -100,6 +100,12 @@
     * 2.6:
         * the prev/next navigation links always are rel=nofollow now, not just
           for years other than the current one.
+    * 2.7:
+        * bots (see cfg.ua_spiders) get no navigation links at all and their
+          calparms are ignored, so there is exactly one calendar url per page
+          for them. Replaces the old "return nothing if the bot navigated more
+          than a year away" handling, which also hid calendars an author had
+          deliberately pointed at a far away year.
 
     Usage:
         <<MonthCalendar(BasePage,year,month,monthoffset,monthoffset2,height6,anniversary,template)>>
@@ -242,8 +248,12 @@ def execute(macro, text):
 
     currentyear, currentmonth, currentday, h, m, s, wd, yd, ds = request.user.getTime(time.time())
     thispage = formatter.page.page_name
+    # A bot gets the calendar as the macro was configured, never a navigated
+    # one, and it gets no navigation links at all (see navigation() below).
+    # That way there is exactly one calendar url per page for it to fetch.
+    is_spider = request.isSpiderAgent
     # does the url have calendar params (= somebody has clicked on prev/next links in calendar) ?
-    if 'calparms' in macro.request.args:
+    if 'calparms' in macro.request.args and not is_spider:
         has_calparms = 1 # yes!
         text2 = macro.request.args['calparms']
         cparmpagename, cparmyear, cparmmonth, cparmoffset, cparmoffset2, cparmheight6, cparmanniversary, cparmtemplate = \
@@ -281,8 +291,6 @@ def execute(macro, text):
         parmoffset2 = clampoffset(parmoffset2, max_nav_offset)
         year, month = yearmonthplusoffset(parmyear, parmmonth, parmoffset)
 
-    if request.isSpiderAgent and abs(currentyear - year) > 1:
-        return '' # this is a bot and it didn't follow the rules (see below)
     # The navigation is never worth indexing: it shows the same day pages the
     # calendar already links, just arranged by month. Used to be done only for
     # years other than the current one, but there is nothing to gain from
@@ -310,8 +318,8 @@ def execute(macro, text):
 
     def navigation(offset, label):
         """ a navigation link moving the calendar to navigation offset <offset>,
-            or just <label> if that offset is out of the allowed range """
-        if abs(offset) > max_nav_offset:
+            or just <label> for a bot or if that offset is out of range """
+        if is_spider or abs(offset) > max_nav_offset:
             return label
         url = p.url(request, querystr % (qpagenames, offset, qtemplate))
         return formatter.url(1, url, 'cal-link', **navattrs) + label + formatter.url(0)

--- a/MoinMoin/web/static/htdocs/modern/css/common.css
+++ b/MoinMoin/web/static/htdocs/modern/css/common.css
@@ -438,7 +438,7 @@ p.searchhint {
 /* MonthCalendar css */
 
 /* days without and with pages linked to them */
-a.cal-emptyday {
+a.cal-emptyday, span.cal-emptyday {
     color: #777777;
     text-align: center;
 }

--- a/MoinMoin/web/static/htdocs/modernized/css/common.css
+++ b/MoinMoin/web/static/htdocs/modernized/css/common.css
@@ -450,7 +450,7 @@ p.searchhint {
 /* MonthCalendar css */
 
 /* days without and with pages linked to them */
-a.cal-emptyday {
+a.cal-emptyday, span.cal-emptyday {
     color: #777777;
     text-align: center;
 }

--- a/MoinMoin/web/static/htdocs/rightsidebar/css/common.css
+++ b/MoinMoin/web/static/htdocs/rightsidebar/css/common.css
@@ -344,7 +344,7 @@ div.codearea pre span.DiffSeparator {color: #228B22; font-weight: bold}
 /* MonthCalendar css */
 
 /* days without and with pages linked to them */
-a.cal-emptyday {
+a.cal-emptyday, span.cal-emptyday {
     color: #777777;
     text-align: center;
 }

--- a/docs/CHANGES
+++ b/docs/CHANGES
@@ -5037,7 +5037,7 @@ New features:
     * Added email notification features contributed by Daniel Sa�    * SystemInfo: show "Entries in edit log"
     * Added "RSS" icon to RecentChanges macro and code to generate a
       RecentChanges RSS channel, see
-          http://www.usemod.com/cgi-bin/mb.pl?UnifiedRecentChanges
+          http://meatballwiki.org/wiki/?UnifiedRecentChanges
       for details
     * Added config.sitename and config.interwikiname parameter
     * Better WikiFarm support:

--- a/wiki/data/intermap.txt
+++ b/wiki/data/intermap.txt
@@ -47,7 +47,7 @@ AltLinux http://altlinux.org/
 AltLinuxEn http://en.altlinux.org/
 hg https://www.mercurial-scm.org/wiki/
 
-## Updated 2004-11-19 from http://www.usemod.com/cgi-bin/mb.pl?InterMapTxt
+## Updated 2004-11-19 from http://meatballwiki.org/wiki/?InterMapTxt
 ## Please modify the upper part of this page only
 
 AbbeNormal http://ourpla.net/cgi/pikie?
@@ -82,7 +82,7 @@ JuraWiki https://jurawiki.de/
 LinuxWiki https://linuxwiki.org/
 LiveJournal http://www.livejournal.com/users/$PAGE/
 LyricWiki http://lyricwiki.org/
-MeatBall http://www.usemod.com/cgi-bin/mb.pl?
+MeatBall http://meatballwiki.org/wiki/?
 MetaWiki http://sunir.org/apps/meta.pl?
 MetaWikiPedia http://meta.wikipedia.org/wiki/
 MoinMaster https://master.moinmo.in/
@@ -103,7 +103,7 @@ ThoughtStorms http://www.nooranch.com/synaesmedia/wiki/wiki.cgi?
 TWiki http://twiki.org/cgi-bin/view/
 UPC http://www.upcdatabase.com/item/
 Unreal http://wiki.beyondunreal.com/wiki/
-UseMod http://www.usemod.com/cgi-bin/wiki.pl?
+UseMod http://www.usemod.org/cgi-bin/wiki.pl?
 WebSeitzWiki http://webseitz.fluxent.com/wiki/
 Wiki http://c2.com/cgi/wiki?
 WikiPedia https://en.wikipedia.org/wiki/

--- a/wiki/data/intermap.txt
+++ b/wiki/data/intermap.txt
@@ -89,7 +89,6 @@ MoinMaster https://master.moinmo.in/
 MoinMoin https://moinmo.in/
 OddMuse http://www.oddmuse.org/
 OpenWiki http://openwiki.com/ow.asp?
-Parawiki http://www.parawiki.org/index.php/ 
 PersonalTelco http://www.personaltelco.net/index.cgi/
 PythonInfo https://wiki.python.org/moin/ 
 PythonWiki http://wiki.python.de/


### PR DESCRIPTION
## Summary

- merge `moinwiki/moin-1.9` through upstream commit `8c6341e9`
- bring in crawler-safe history, diff, and `MonthCalendar` navigation changes
- update the default history page size and interwiki data
- preserve this fork's Python 3 context API and integer-division behavior while resolving conflicts

## Validation

- `python -m py_compile` passed for the four reconciled Python modules
- targeted diff and configuration tests passed: 4 passed
- the broader suite reached 396 passing tests, but remains blocked by unrelated Python 3.14 compatibility issues, legacy fixture assumptions, and the unavailable optional `xapian` dependency
