### PR TITLE
Fix Python 3 string and bytes compatibility

### DIFF
--- a/MoinMoin/action/AttachFile.py
+++ b/MoinMoin/action/AttachFile.py
@@ -32,7 +32,7 @@ import os
 import tarfile
 import time
 import zipfile
-from io import StringIO
+from io import BytesIO
 
 from werkzeug.http import http_date
 
@@ -816,13 +816,17 @@ class ContainerItem:
     def put(self, member, content, content_length=None):
         """ save data into a container's member """
         tf = tarfile.TarFile(self.container_filename, mode='a')
-        if isinstance(member, str):
-            member = member.encode('utf-8')
+        if isinstance(member, bytes):
+            member = member.decode('utf-8')
         ti = tarfile.TarInfo(member)
         if isinstance(content, str):
+            content = content.encode('utf-8')
+            content_length = len(content)
+            content = BytesIO(content)
+        elif isinstance(content, bytes):
             if content_length is None:
                 content_length = len(content)
-            content = StringIO(content)  # we need a file obj
+            content = BytesIO(content)
         elif not hasattr(content, 'read'):
             msg = "unsupported content object: %r" % content
             logging.error(msg)
@@ -833,8 +837,8 @@ class ContainerItem:
         tf.close()
 
     def truncate(self):
-        f = open(self.container_filename, 'w')
-        f.close()
+        with tarfile.open(self.container_filename, mode='w'):
+            pass
 
     def exists(self):
         return os.path.exists(self.container_filename)
@@ -1143,7 +1147,6 @@ def _do_unzip(pagename, request, overwrite=False):
                     mapping = []  # zip is not acceptable
                     break
                 finalname = name[fname_index:]  # remove common path prefix
-                finalname = finalname.decode(config.charset, 'replace')  # replaces trash with \uFFFD char
                 mapping.append((name, finalname))
                 new_fsizes[finalname] = zi.file_size
 
@@ -1367,7 +1370,7 @@ def do_admin_browser(request):
                 data.addRow((
                     (Page(request, pagename).link_to(request,
                                                      querystr="action=AttachFile"), wikiutil.escape(pagename, 1)),
-                    wikiutil.escape(filename.decode(config.charset)),
+                    wikiutil.escape(filename),
                     os.path.getsize(filepath),
                 ))
 

--- a/MoinMoin/action/PackagePages.py
+++ b/MoinMoin/action/PackagePages.py
@@ -81,7 +81,7 @@ class PackagePages:
             raise ActionError
 
         request = self.request
-        filelike = io.StringIO()
+        filelike = io.BytesIO()
         package = self.collectpackage(unpackLine(pagelist, ","), filelike, target, include_attachments)
         request.headers['Content-Type'] = 'application/zip'
         request.headers['Content-Length'] = filelike.tell()

--- a/MoinMoin/action/SyncPages.py
+++ b/MoinMoin/action/SyncPages.py
@@ -42,9 +42,9 @@ class ActionClass:
 
     def log_status(self, level, message=u"", substitutions=(), raw_suffix=u""):
         """ Appends the message with a given importance level to the internal log. """
-        if isinstance(message, str):
+        if isinstance(message, bytes):
             message = message.decode("utf-8")
-        if isinstance(raw_suffix, str):
+        if isinstance(raw_suffix, bytes):
             raw_suffix = raw_suffix.decode("utf-8")
         self.status.append((level, message, substitutions, raw_suffix))
 

--- a/MoinMoin/action/newpage.py
+++ b/MoinMoin/action/newpage.py
@@ -49,9 +49,7 @@ class NewPage:
             template = self.nametemplate.replace('%s', repl)
         else:
             template = self.nametemplate
-        template = template.encode('utf-8')
         template = time.strftime(template, self.request.user.getTime(time.time()))
-        template = template.decode('utf-8')
         if need_replace:
             self.pagename = template.replace(repl, self.pagename)
         else:

--- a/MoinMoin/action/pollsistersites.py
+++ b/MoinMoin/action/pollsistersites.py
@@ -39,9 +39,9 @@ def execute(pagename, request):
             for line in f:
                 line = line.strip()
                 try:
-                    page_url, page_name = line.split(' ', 1)
-                    sisterpages[page_name.decode('utf-8')] = page_url
-                except:
+                    page_url, page_name = line.decode('utf-8').split(' ', 1)
+                    sisterpages[page_name] = page_url
+                except (UnicodeDecodeError, ValueError):
                     pass  # ignore invalid lines
             try:
                 lastmod = f.info()["Last-Modified"]

--- a/MoinMoin/auth/__init__.py
+++ b/MoinMoin/auth/__init__.py
@@ -332,7 +332,7 @@ class GivenAuth(BaseAuth):
 
     def decode_username(self, name):
         """ decode the name we got from the environment var to unicode """
-        if isinstance(name, str):
+        if isinstance(name, bytes):
             if self.coding:
                 name = name.decode(self.coding)
             else:

--- a/MoinMoin/auth/cas.py
+++ b/MoinMoin/auth/cas.py
@@ -57,7 +57,7 @@ class PyCAS:
         """Validate the given ticket against the given service."""
         f = urllib.request.urlopen(self.validate_url(service, ticket))
         valid = f.readline()
-        valid = valid.strip() == 'yes'
+        valid = valid.strip() == b'yes'
         user = f.readline().strip()
         user = user.decode(self.coding)
         return valid, user
@@ -119,4 +119,3 @@ class CASAuth(BaseAuth):
             user_obj.valid = False
 
         return user_obj, True
-

--- a/MoinMoin/auth/http.py
+++ b/MoinMoin/auth/http.py
@@ -45,6 +45,7 @@ from MoinMoin import log
 logging = log.getLogger(__name__)
 
 from MoinMoin import user
+from MoinMoin import wikiutil
 from MoinMoin.auth import BaseAuth, GivenAuth
 
 
@@ -81,8 +82,8 @@ class HTTPAuthMoin(BaseAuth):
             logging.debug("http basic auth, received username: %r password: %r" % (
                           auth.username, auth.password))
             u = user.User(request,
-                          name=auth.username.decode(self.coding),
-                          password=auth.password.decode(self.coding),
+                          name=wikiutil.decodeUserInput(auth.username, [self.coding]),
+                          password=wikiutil.decodeUserInput(auth.password, [self.coding]),
                           auth_method=self.name, auth_attribs=[])
             logging.debug("user: %r" % u)
 
@@ -103,4 +104,3 @@ class HTTPAuthMoin(BaseAuth):
         else:
             logging.debug("returning %r" % user_obj)
             return user_obj, True
-

--- a/MoinMoin/auth/ldap_login.py
+++ b/MoinMoin/auth/ldap_login.py
@@ -20,13 +20,13 @@ from MoinMoin import log
 from MoinMoin import user
 from MoinMoin.auth import BaseAuth, CancelLogin, ContinueLogin
 
+logging = log.getLogger(__name__)
+
 try:
     import ldap
 except ImportError as err:
     logging.error("You need to have python-ldap installed (%s)." % str(err))
     raise
-
-logging = log.getLogger(__name__)
 
 
 class LDAPAuth(BaseAuth):
@@ -211,7 +211,9 @@ class LDAPAuth(BaseAuth):
 
                 if self.email_callback is None:
                     if self.email_attribute:
-                        email = ldap_dict.get(self.email_attribute, [''])[0].decode(coding)
+                        email = ldap_dict.get(self.email_attribute, [b''])[0]
+                        if isinstance(email, bytes):
+                            email = email.decode(coding)
                     else:
                         email = None
                 else:
@@ -223,13 +225,18 @@ class LDAPAuth(BaseAuth):
                 except (KeyError, IndexError):
                     pass
                 if not aliasname:
-                    sn = ldap_dict.get(self.surname_attribute, [''])[0]
-                    gn = ldap_dict.get(self.givenname_attribute, [''])[0]
+                    sn = ldap_dict.get(self.surname_attribute, [b''])[0]
+                    gn = ldap_dict.get(self.givenname_attribute, [b''])[0]
+                    if isinstance(sn, bytes):
+                        sn = sn.decode(coding)
+                    if isinstance(gn, bytes):
+                        gn = gn.decode(coding)
                     if sn and gn:
                         aliasname = "%s, %s" % (sn, gn)
                     elif sn:
                         aliasname = sn
-                aliasname = aliasname.decode(coding)
+                if isinstance(aliasname, bytes):
+                    aliasname = aliasname.decode(coding)
 
                 if self.name_callback:
                     username = self.name_callback(ldap_dict)

--- a/MoinMoin/auth/php_session.py
+++ b/MoinMoin/auth/php_session.py
@@ -48,14 +48,14 @@ class PHPSessionAuth(BaseAuth):
             name = user_info.get('fullname', '')
             email = user_info.get('email', '')
 
-            dec = lambda x: x and x.decode("iso-8859-1")
+            dec = lambda x: x.decode("iso-8859-1") if isinstance(x, bytes) else x
 
             return dec(username), dec(email), dec(name)
 
         cookie = kw.get('cookie')
         if not cookie is None:
             for cookiename in cookie:
-                cookievalue = urllib.parse.unquote(cookie[cookiename].value).decode('iso-8859-1')
+                cookievalue = urllib.parse.unquote_to_bytes(cookie[cookiename].value).decode('iso-8859-1')
                 session = _PHPsessionParser.loadSession(cookievalue, path=self.s_path, prefix=self.s_prefix)
                 if session:
                     if "egw" in self.apps and session.get('egw_session', None):
@@ -80,4 +80,3 @@ class PHPSessionAuth(BaseAuth):
             if u and u.valid:
                 return u, True # True to get other methods called, too
         return user_obj, True # continue with next method in auth list
-

--- a/MoinMoin/auth/sslclientcert.py
+++ b/MoinMoin/auth/sslclientcert.py
@@ -13,6 +13,13 @@
 from MoinMoin import config, user
 from MoinMoin.auth import BaseAuth
 
+
+def _decode(value):
+    if isinstance(value, bytes):
+        return value.decode(config.charset)
+    return value
+
+
 class SSLClientCertAuth(BaseAuth):
     """ authenticate via SSL client certificate """
 
@@ -44,11 +51,11 @@ class SSLClientCertAuth(BaseAuth):
 
             email_lower = None
             if self.email_key:
-                email = env.get('SSL_CLIENT_S_DN_Email', '').decode(config.charset)
+                email = _decode(env.get('SSL_CLIENT_S_DN_Email', ''))
                 email_lower = email.lower()
             commonname_lower = None
             if self.name_key:
-                commonname = env.get('SSL_CLIENT_S_DN_CN', '').decode(config.charset)
+                commonname = _decode(env.get('SSL_CLIENT_S_DN_CN', ''))
                 commonname_lower = commonname.lower()
             if email_lower or commonname_lower:
                 for uid in user.getUserList(request):

--- a/MoinMoin/config/multiconfig.py
+++ b/MoinMoin/config/multiconfig.py
@@ -518,7 +518,8 @@ class ConfigFunctionality:
         try:
             iwid = self.meta_dict['IWID']
         except KeyError:
-            iwid = util.random_string(16).encode("hex") + "-" + str(int(time.time()))
+            random_part = util.random_string(16).encode('latin-1').hex()
+            iwid = random_part + "-" + str(int(time.time()))
             self.meta_dict['IWID'] = iwid
             self.meta_dict.sync()
 

--- a/MoinMoin/filter/application_vnd_oasis_opendocument.py
+++ b/MoinMoin/filter/application_vnd_oasis_opendocument.py
@@ -20,16 +20,10 @@ rx_stripxml = re.compile("<[^>]*?>", re.DOTALL|re.MULTILINE)
 def execute(indexobj, filename):
     try:
         zf = zipfile.ZipFile(filename, "r")
-        data = zf.read("content.xml")
+        data = zf.read("content.xml").decode('utf-8')
         zf.close()
         data = " ".join(rx_stripxml.sub(" ", data).split())
-    except (zipfile.BadZipfile, RuntimeError) as err:
+    except (UnicodeDecodeError, zipfile.BadZipfile, RuntimeError) as err:
         logging.error("%s [%s]" % (str(err), filename))
-        data = ""
-    try:
-        data = data.decode('utf-8')
-    except UnicodeDecodeError:
-        # protected with password? no valid OpenDocument file?
         data = u''
     return data
-

--- a/MoinMoin/filter/application_vnd_sun_xml.py
+++ b/MoinMoin/filter/application_vnd_sun_xml.py
@@ -20,16 +20,10 @@ rx_stripxml = re.compile("<[^>]*?>", re.DOTALL|re.MULTILINE)
 def execute(indexobj, filename):
     try:
         zf = zipfile.ZipFile(filename, "r")
-        data = zf.read("content.xml")
+        data = zf.read("content.xml").decode('utf-8')
         zf.close()
         data = " ".join(rx_stripxml.sub(" ", data).split())
-    except (zipfile.BadZipfile, RuntimeError) as err:
+    except (UnicodeDecodeError, zipfile.BadZipfile, RuntimeError) as err:
         logging.error("%s [%s]" % (str(err), filename))
-        data = ""
-    try:
-        data = data.decode('utf-8')
-    except UnicodeDecodeError:
-        # protected with password? no valid OpenOffice file?
         data = u''
     return data
-

--- a/MoinMoin/filter/image_jpeg.py
+++ b/MoinMoin/filter/image_jpeg.py
@@ -22,10 +22,9 @@ def execute(indexobj, filename):
             del tags["EXIF MakerNote"]
         except:
             pass
-        data = str(tags).decode('utf-8')
+        data = str(tags)
     except (ValueError, TypeError, KeyError): # EXIF throws ValueError on unknown tags
                                               # TypeError on other occassions
                                               # KeyError too
         data = u''
     return data
-

--- a/MoinMoin/i18n/tools/po2wiki.py
+++ b/MoinMoin/i18n/tools/po2wiki.py
@@ -29,8 +29,6 @@ def run():
         f.close()
         sys.exit(0)
 
-    data = data.decode('utf-8')
-
     cutpos = data.index(u"msgid")
     data = data[cutpos:] # remove comments at top
 
@@ -64,4 +62,3 @@ def run():
 
 if __name__ == "__main__":
     run()
-

--- a/MoinMoin/parser/text_csv.py
+++ b/MoinMoin/parser/text_csv.py
@@ -53,7 +53,6 @@ class Parser:
         self._first_row = None
         formatter = request.formatter
 
-        # workaround csv.reader deficiency by encoding to utf-8
         # removes empty lines in front of the csv table
         data = raw.lstrip('\n').split('\n')
 
@@ -85,7 +84,6 @@ class Parser:
         args = next(hdr)
 
         for arg in args:
-            arg = arg.decode('utf-8')
             try:
                 key, val = arg.split('=', 1)
             except:
@@ -96,13 +94,17 @@ class Parser:
                     except ValueError:
                         pass
                 else:
-                    delimiter = arg.encode('utf-8')
+                    delimiter = arg
                 continue
             if key == 'separator' or key == 'delimiter':
-                delimiter = val.encode('utf-8')
+                delimiter = val
             if key == 'quotechar':
-                if val == val.encode('utf-8'):
-                    quotechar = val.encode('utf-8')
+                try:
+                    val.encode('ascii')
+                except UnicodeEncodeError:
+                    pass
+                else:
+                    quotechar = val
                     quoting = QUOTE_MINIMAL
             elif key == 'show':
                 visible = val.split(',')

--- a/MoinMoin/parser/text_xslt.py
+++ b/MoinMoin/parser/text_xslt.py
@@ -82,7 +82,7 @@ class Parser:
                         self.supportedSchemes.append(base_scheme)
 
                 # setting up vars for xslt Processor
-                out_file = io.StringIO()
+                out_file = io.BytesIO()
                 wiki_resolver = MoinResolver(
                     handlers={self.base_scheme: self._resolve_page, },
                     base_scheme=self.base_scheme)
@@ -115,7 +115,7 @@ class Parser:
                 before = _('%(errortype)s processing error') % {'errortype': etype, }
                 title = u"<strong>%s: %s</strong><p>" % (before, msg)
                 self.request.write(title)
-                self.request.write(text.decode(config.charset))
+                self.request.write(text)
             else:
                 self.request.write(result)
                 cache = caching.CacheEntry(self.request, formatter.page, self.key, scope='item')
@@ -130,7 +130,7 @@ class Parser:
             pagename = uri[len(base_uri):]
             page = Page.Page(self.request, pagename)
             if page.exists():
-                result = io.StringIO(page.getPageText().encode(config.charset))
+                result = io.BytesIO(page.getPageText().encode(config.charset))
             else:
                 raise Uri.UriException(Uri.UriException.RESOURCE_ERROR, loc=uri,
                                        msg='Page does not exist')

--- a/MoinMoin/script/account/resetpw.py
+++ b/MoinMoin/script/account/resetpw.py
@@ -128,8 +128,8 @@ newpassword:
         if text_file:
             text_intro = ''
             text_msg = ''
-            with open(text_file) as f:
-                text_data = f.read().decode('utf-8')
+            with open(text_file, encoding='utf-8') as f:
+                text_data = f.read()
 
         if self.options.uid:
             try:

--- a/MoinMoin/script/migration/_conv160.py
+++ b/MoinMoin/script/migration/_conv160.py
@@ -120,7 +120,7 @@ class EventLog:
                 kvpairs = wikiutil.makeQueryString(kvdict)
                 fields = str(timestamp), action, kvpairs
                 line = '\t'.join(fields) + '\n'
-                f.write(line)
+                f.write(line.encode(config.charset))
             f.close()
 
     def copy(self, destfname, renames):
@@ -176,9 +176,9 @@ class EditLog:
                 timestamp, rev, action, pagename, ip, hostname, userid, extra, comment = fields
                 if action.startswith('ATT'):
                     try:
-                        fname = urllib.parse.unquote(extra).decode('utf-8')
+                        fname = urllib.parse.unquote_to_bytes(extra).decode('utf-8')
                     except UnicodeDecodeError:
-                        fname = urllib.parse.unquote(extra).decode('iso-8859-1')
+                        fname = urllib.parse.unquote_to_bytes(extra).decode('iso-8859-1')
                     if ('FILE', pagename, fname) in self.renames:
                         fname = self.renames[('FILE', pagename, fname)]
                     extra = urllib.parse.quote(fname.encode('utf-8'))
@@ -191,7 +191,7 @@ class EditLog:
                 pagename = wikiutil.quoteWikinameFS(pagename)
                 fields = timestamp, revstr, action, pagename, ip, hostname, userid, extra, comment
                 log_str = '\t'.join(fields) + '\n'
-                f.write(log_str)
+                f.write(log_str.encode(config.charset))
             if create_rev and not deleted:
                 timestamp = str(wikiutil.timestamp2version(time.time()))
                 revstr = '%08d' % (max_rev + 1)
@@ -203,7 +203,7 @@ class EditLog:
                 comment = "converted to 1.6 markup"
                 fields = timestamp, revstr, action, pagename, ip, hostname, userid, extra, comment
                 log_str = '\t'.join(fields) + '\n'
-                f.write(log_str)
+                f.write(log_str.encode(config.charset))
             f.close()
 
     def copy(self, destfname, renames, deleted=False):
@@ -250,12 +250,11 @@ class Attachment:
     def __init__(self, request, attach_dir, attfile):
         self.request = request
         self.path = opj(attach_dir, attfile)
-        self.name = attfile.decode('utf-8', 'replace')
+        self.name = attfile
 
     def copy(self, attach_dir):
         """ copy attachment file from orig path to new destination """
-        attfile = self.name.encode('utf-8')
-        dest = opj(attach_dir, attfile)
+        dest = opj(attach_dir, self.name)
         copy_file(self.path, dest)
 
 
@@ -580,5 +579,3 @@ class DataConverter:
         os.makedirs(opj(self.ddata, 'user'))
         copy_dir(opj(self.sdata, 'plugin'), opj(self.ddata, 'plugin'))
         copy_file(opj(self.sdata, 'intermap.txt'), opj(self.ddata, 'intermap.txt'))
-
-

--- a/MoinMoin/script/migration/_conv160a.py
+++ b/MoinMoin/script/migration/_conv160a.py
@@ -114,7 +114,7 @@ class EventLog:
                 kvpairs = wikiutil.makeQueryString(kvdict)
                 fields = str(timestamp), action, kvpairs
                 line = '\t'.join(fields) + '\n'
-                f.write(line)
+                f.write(line.encode(config.charset))
             f.close()
 
     def copy(self, destfname, renames):
@@ -172,9 +172,9 @@ class EditLog:
                 timestamp, rev, action, pagename, ip, hostname, userid, extra, comment = fields
                 if action.startswith('ATT'):
                     try:
-                        fname = urllib.parse.unquote(extra).decode('utf-8')
+                        fname = urllib.parse.unquote_to_bytes(extra).decode('utf-8')
                     except UnicodeDecodeError:
-                        fname = urllib.parse.unquote(extra).decode('iso-8859-1')
+                        fname = urllib.parse.unquote_to_bytes(extra).decode('iso-8859-1')
                     if ('FILE', pagename, fname) in self.renames:
                         fname = self.renames[('FILE', pagename, fname)]
                     extra = urllib.parse.quote(fname.encode('utf-8'))
@@ -187,7 +187,7 @@ class EditLog:
                 pagename = wikiutil.quoteWikinameFS(pagename)
                 fields = timestamp, revstr, action, pagename, ip, hostname, userid, extra, comment
                 log_str = '\t'.join(fields) + '\n'
-                f.write(log_str)
+                f.write(log_str.encode(config.charset))
             if create_rev and not deleted:
                 timestamp = str(wikiutil.timestamp2version(time.time()))
                 revstr = '%08d' % (max_rev + 1)
@@ -199,7 +199,7 @@ class EditLog:
                 comment = "converted to 1.6 markup"
                 fields = timestamp, revstr, action, pagename, ip, hostname, userid, extra, comment
                 log_str = '\t'.join(fields) + '\n'
-                f.write(log_str)
+                f.write(log_str.encode(config.charset))
             f.close()
 
     def copy(self, destfname, renames, deleted=False):
@@ -248,12 +248,11 @@ class Attachment:
     def __init__(self, request, attach_dir, attfile):
         self.request = request
         self.path = opj(attach_dir, attfile)
-        self.name = attfile.decode('utf-8', 'replace')
+        self.name = attfile
 
     def copy(self, attach_dir):
         """ copy attachment file from orig path to new destination """
-        attfile = self.name.encode('utf-8')
-        dest = opj(attach_dir, attfile)
+        dest = opj(attach_dir, self.name)
         copy_file(self.path, dest)
 
 

--- a/MoinMoin/script/migration/wikiutil160a.py
+++ b/MoinMoin/script/migration/wikiutil160a.py
@@ -6,7 +6,6 @@
     @license: GNU GPL, see COPYING for details.
 """
 
-import cgi
 import codecs
 import hashlib
 import os
@@ -150,18 +149,12 @@ def url_unquote(s, want_unicode=True):
 def parseQueryString(qstr, want_unicode=True):
     """ Parse a querystring "key=value&..." into a dict.
     """
-    is_unicode = isinstance(qstr, str)
-    if is_unicode:
-        qstr = qstr.encode(config.charset)
+    if isinstance(qstr, bytes):
+        qstr = qstr.decode(config.charset)
     values = {}
-    for key, value in list(cgi.parse_qs(qstr).items()):
+    for key, value in urllib.parse.parse_qs(qstr).items():
         if len(value) < 2:
             v = ''.join(value)
-            if want_unicode:
-                try:
-                    v = str(v, config.charset)
-                except UnicodeDecodeError:
-                    v = str(v, 'iso-8859-1', 'replace')
             values[key] = v
     return values
 

--- a/MoinMoin/security/textcha.py
+++ b/MoinMoin/security/textcha.py
@@ -85,7 +85,8 @@ class TextCha:
 
     def _compute_signature(self, question, timestamp):
         signature = u"%s%d" % (question, timestamp)
-        return hmac.new(self.secret, signature.encode('utf-8'), digestmod=hashlib.sha1).hexdigest()
+        secret = self.secret.encode('utf-8') if isinstance(self.secret, str) else self.secret
+        return hmac.new(secret, signature.encode('utf-8'), digestmod=hashlib.sha1).hexdigest()
 
     def _init_qa(self, question=None):
         """ Initialize the question / answer.

--- a/MoinMoin/stats/hitcounts.py
+++ b/MoinMoin/stats/hitcounts.py
@@ -215,7 +215,7 @@ def draw(pagename, context):
     edits = [x * scalefactor for x in edits]
 
     # create image
-    image = io.StringIO()
+    image = io.BytesIO()
     c = Chart()
     c.addData(ChartData(views, color='green'))
     c.addData(ChartData(edits, color='red'))
@@ -253,5 +253,5 @@ def draw(pagename, context):
     context.response.content_length = len(image.getvalue())
 
     # copy the image
-    image.reset()
+    image.seek(0)
     shutil.copyfileobj(image, context, 8192)

--- a/MoinMoin/stats/pagesize.py
+++ b/MoinMoin/stats/pagesize.py
@@ -85,7 +85,7 @@ def draw(pagename, request):
             '<br>'.join([wikiutil.escape(repr(x)) for x in [labels, data]])
 
     # create image
-    image = io.StringIO()
+    image = io.BytesIO()
     c = Chart()
     ##c.addData(ChartData(data, 'magenta'))
     c.addData(ChartData(_slice(data, 0, 7), 'blue'))
@@ -116,5 +116,5 @@ def draw(pagename, request):
     request.content_length = len(image.getvalue())
 
     # copy the image
-    image.reset()
+    image.seek(0)
     shutil.copyfileobj(image, request, 8192)

--- a/MoinMoin/stats/useragents.py
+++ b/MoinMoin/stats/useragents.py
@@ -151,7 +151,7 @@ def draw(pagename, request):
             '<br>'.join([wikiutil.escape(repr(x)) for x in [labels, data]])
 
     # create image
-    image = io.StringIO()
+    image = io.BytesIO()
     c = Chart()
     c.addData(data)
 
@@ -177,5 +177,5 @@ def draw(pagename, request):
     request.content_length = len(image.getvalue())
 
     # copy the image
-    image.reset()
+    image.seek(0)
     shutil.copyfileobj(image, request, 8192)

--- a/MoinMoin/support/BasicAuthTransport.py
+++ b/MoinMoin/support/BasicAuthTransport.py
@@ -2,8 +2,8 @@
 
 
 
+import base64
 import xmlrpc.client, http.client
-from base64 import encodestring
 
 class BasicAuthTransport(xmlrpc.client.Transport):
     def __init__(self, username=None, password=None):
@@ -26,7 +26,8 @@ class BasicAuthTransport(xmlrpc.client.Transport):
 
         # basic auth
         if self.username is not None and self.password is not None:
-            authhdr = "Basic %s" % encodestring("%s:%s" % (self.username, self.password)).replace("\012", "")
+            credentials = ("%s:%s" % (self.username, self.password)).encode('utf-8')
+            authhdr = "Basic %s" % base64.b64encode(credentials).decode('ascii')
             h.putheader("Authorization", authhdr)
         h.endheaders()
 
@@ -43,4 +44,3 @@ class BasicAuthTransport(xmlrpc.client.Transport):
                 )
 
         return self.parse_response(h.getfile())
-

--- a/MoinMoin/support/python_compatibility.py
+++ b/MoinMoin/support/python_compatibility.py
@@ -8,9 +8,7 @@
     @license: GNU GPL, see COPYING for details.
 """
 
-import string
-
-rsplit = string.rsplit
+rsplit = str.rsplit
 
 sorted = sorted
 
@@ -24,4 +22,8 @@ import hashlib, hmac
 hash_new = hashlib.new
 
 def hmac_new(key, msg, digestmod=hashlib.sha1):
+    if isinstance(key, str):
+        key = key.encode('utf-8')
+    if isinstance(msg, str):
+        msg = msg.encode('utf-8')
     return hmac.new(key, msg, digestmod)

--- a/MoinMoin/user.py
+++ b/MoinMoin/user.py
@@ -266,7 +266,7 @@ def getUserIdentification(request, username=None):
     return username or (request.cfg.show_hosts and request.request.remote_addr) or _("<unknown>")
 
 
-def encodePassword(cfg, pwd, salt: bytes = None, scheme=None):
+def encodePassword(cfg, pwd, salt=None, scheme=None):
     """ Encode a cleartext password using the default algorithm.
 
     @param cfg: the wiki config
@@ -283,12 +283,15 @@ def encodePassword(cfg, pwd, salt: bytes = None, scheme=None):
     else:
         configured_scheme = False
     if scheme == '{PASSLIB}':
+        if isinstance(salt, bytes):
+            salt = salt.decode('ascii')
         return '{PASSLIB}' + cfg.cache.pwd_context.encrypt(pwd, salt=salt)
     elif scheme == '{SSHA}':
         pwd = pwd.encode('utf-8')
         if salt is None:
-            salt = random_string(20)
-        assert isinstance(salt, bytes)
+            salt = random_string(20).encode('latin-1')
+        elif isinstance(salt, str):
+            salt = salt.encode('utf-8')
         hash = hashlib.new('sha1', pwd)
         hash.update(salt)
         return '{SSHA}' + base64.encodebytes(hash.digest() + salt).decode("ascii").rstrip()
@@ -1273,7 +1276,7 @@ class User:
     def generate_recovery_token(self):
         key = random_string(64, "abcdefghijklmnopqrstuvwxyz0123456789")
         msg = str(int(time.time()))
-        h = hmac.new(key, msg, digestmod=hashlib.sha1).hexdigest()
+        h = hmac.new(key.encode('ascii'), msg.encode('ascii'), digestmod=hashlib.sha1).hexdigest()
         self.recoverpass_key = key
         self.save()
         return msg + '-' + h
@@ -1289,9 +1292,10 @@ class User:
         lifetime = self._request.cfg.recovery_token_lifetime * 3600
         if time.time() > stamp + lifetime:
             return False
-        # check hmac
-        # key must be of type string
-        h = hmac.new(str(self.recoverpass_key), str(stamp), digestmod=hashlib.sha1).hexdigest()
+        # Check the token using the same ASCII representation used when it was generated.
+        key = str(self.recoverpass_key).encode('ascii')
+        msg = str(stamp).encode('ascii')
+        h = hmac.new(key, msg, digestmod=hashlib.sha1).hexdigest()
         if not safe_str_cmp(h, parts[1]):
             return False
         self.recoverpass_key = ""

--- a/MoinMoin/userprefs/oidserv.py
+++ b/MoinMoin/userprefs/oidserv.py
@@ -78,7 +78,7 @@ class Settings(UserPrefBase):
         _ = self.request.getText
         form = self._make_form()
         for root in self.request.user.openid_trusted_roots:
-            display = base64.decodestring(root)
+            display = base64.b64decode(root).decode('utf-8')
             name = 'rm-%s' % root
             form.append(html.INPUT(type="checkbox", name=name, id=name))
             form.append(html.LABEL(for_=name).append(html.Text(display)))

--- a/MoinMoin/util/moinoid.py
+++ b/MoinMoin/util/moinoid.py
@@ -5,6 +5,7 @@
     @license: GNU GPL, see COPYING for details.
 """
 import hashlib
+import base64
 from random import randint
 import time
 
@@ -25,8 +26,7 @@ def log(msg, level=0):
 oidutil.log = log
 
 def strbase64(value):
-    from base64 import encodestring
-    return encodestring(str(value)).replace('\n', '')
+    return base64.b64encode(str(value).encode('utf-8')).decode('ascii')
 
 
 def _cleanup_nonces(request):
@@ -52,6 +52,8 @@ class MoinOpenIDStore(OpenIDStore):
 
     def key(self, url):
         '''return cache key'''
+        if isinstance(url, str):
+            url = url.encode('utf-8')
         return hashlib.new('sha1', url).hexdigest()
 
     def storeAssociation(self, server_url, association):

--- a/MoinMoin/web/static/htdocs/applets/FCKeditor/editor/filemanager/connectors/py/fckcommands.py
+++ b/MoinMoin/web/static/htdocs/applets/FCKeditor/editor/filemanager/connectors/py/fckcommands.py
@@ -96,7 +96,7 @@ class CreateFolderCommandMixin :
 				newFolderPath = mapServerFolder(self.userFilesFolder, combinePaths(currentFolder, newFolder))
 				self.createServerFolder(newFolderPath)
 			except Exception as e:
-				errorMsg = str(e).decode('iso-8859-1').encode('utf-8') # warning with encodigns!!!
+				errorMsg = str(e)
 				if hasattr(e,'errno'):
 					if e.errno==17: #file already exists
 						errorNo=0

--- a/tests/_tests/test_python3_string_compat.py
+++ b/tests/_tests/test_python3_string_compat.py
@@ -1,0 +1,66 @@
+"""
+    Regression tests for Python 3 text and byte boundaries.
+
+    @license: GNU GPL, see COPYING for details.
+"""
+
+import io
+import http.client
+
+import pytest
+
+from MoinMoin.script.migration import _conv160, _conv160a, wikiutil160a
+from MoinMoin.support.BasicAuthTransport import BasicAuthTransport
+from MoinMoin.support.python_compatibility import hmac_new
+
+
+def test_compatibility_hmac_accepts_text():
+    assert hmac_new('key', 'message').hexdigest() == (
+        '2088df74d5f2146b48146caf4965377e9d0be3a4'
+    )
+
+
+def test_basic_auth_header_is_ascii_base64(monkeypatch):
+    class HTTP:
+        def __init__(self):
+            self.headers = {}
+
+        def putrequest(self, method, handler):
+            pass
+
+        def putheader(self, name, value):
+            self.headers[name] = value
+
+        def endheaders(self):
+            pass
+
+        def getreply(self):
+            return 200, 'OK', {}
+
+        def getfile(self):
+            return io.BytesIO()
+
+    connection = HTTP()
+    monkeypatch.setattr(http.client, 'HTTP', lambda host: connection, raising=False)
+    transport = BasicAuthTransport('Jürgen', 'secret')
+    monkeypatch.setattr(transport, 'parse_response', lambda stream: 'response')
+
+    assert transport.request('example.test', '/RPC2', b'') == 'response'
+    assert connection.headers['Authorization'] == 'Basic SsO8cmdlbjpzZWNyZXQ='
+
+
+def test_migration_query_string_decodes_bytes():
+    assert wikiutil160a.parseQueryString(b'name=J%C3%BCrgen') == {
+        'name': 'Jürgen',
+    }
+
+
+@pytest.mark.parametrize('module', [_conv160, _conv160a])
+def test_migration_event_log_writes_encoded_bytes(module, tmp_path):
+    target = tmp_path / 'event-log'
+    event_log = module.EventLog(None, str(target))
+    event_log.data = [(1234567890, 'SAVE', {'pagename': 'Jürgen'})]
+
+    event_log.write(str(target))
+
+    assert target.read_bytes().startswith(b'1234567890\tSAVE\t')

--- a/tests/_tests/test_user.py
+++ b/tests/_tests/test_user.py
@@ -43,6 +43,17 @@ class TestEncodePassword:
             assert result == expected
 
 
+def test_recovery_token_roundtrip(req, monkeypatch):
+    account = user.User(req)
+    monkeypatch.setattr(user.User, 'save', lambda self: None)
+
+    token = account.generate_recovery_token()
+
+    assert account.apply_recovery_token(token, 'new password')
+    assert account.recoverpass_key == ''
+    assert account.enc_password.startswith(req.cfg.password_scheme)
+
+
 class TestLoginWithPassword:
     """user: login tests"""
 
@@ -341,4 +352,3 @@ class TestIsValidName:
 
 
 coverage_modules = ['MoinMoin.user']
-

--- a/tests/action/_tests/test_attachfile.py
+++ b/tests/action/_tests/test_attachfile.py
@@ -67,4 +67,15 @@ class TestAttachFile:
 
         assert file_exists
 
+    def test_container_accepts_unicode_text(self, req):
+        become_trusted(req)
+        container = AttachFile.ContainerItem(req, self.pagename, 'drawing.tar')
+        container.truncate()
+
+        container.put('drawing.map', 'Grüße')
+
+        assert container.get('drawing.map').read() == 'Grüße'.encode('utf-8')
+        nuke_page(req, self.pagename)
+
+
 coverage_modules = ['MoinMoin.action.AttachFile']

--- a/tests/auth/_tests/test_given.py
+++ b/tests/auth/_tests/test_given.py
@@ -1,0 +1,14 @@
+"""
+    Tests for authentication values supplied by the web server.
+
+    @license: GNU GPL, see COPYING for details.
+"""
+
+from MoinMoin.auth import GivenAuth
+
+
+def test_given_auth_decodes_only_bytes():
+    auth = GivenAuth(coding='utf-8')
+
+    assert auth.decode_username('Jürgen') == 'Jürgen'
+    assert auth.decode_username('Jürgen'.encode('utf-8')) == 'Jürgen'

--- a/tests/config/_tests/test_multiconfig.py
+++ b/tests/config/_tests/test_multiconfig.py
@@ -12,6 +12,8 @@ import sys
 
 import pytest
 
+from MoinMoin.config import multiconfig
+
 
 def test_plugin_package_is_registered(req):
     module_name = req.cfg._plugin_modules[0]
@@ -19,6 +21,24 @@ def test_plugin_package_is_registered(req):
 
     assert module.__name__ == module_name
     assert module.__path__ == [os.path.abspath(req.cfg.plugin_dir)]
+
+
+def test_iwid_generation_uses_hex_text(req, monkeypatch):
+    class MetaDict(dict):
+        def sync(self):
+            self.synced = True
+
+    meta = MetaDict()
+    monkeypatch.setattr(req.cfg, '_meta_dict', meta)
+    monkeypatch.setattr(multiconfig.util, 'random_string',
+                        lambda length: ''.join(chr(value) for value in range(length)))
+    monkeypatch.setattr(multiconfig.time, 'time', lambda: 1234567890)
+
+    req.cfg.load_IWID()
+
+    assert req.cfg.iwid == '000102030405060708090a0b0c0d0e0f-1234567890'
+    assert meta['IWID'] == req.cfg.iwid
+    assert meta.synced
 
 
 class TestPasswordChecker:

--- a/tests/filter/_tests/test_filter.py
+++ b/tests/filter/_tests/test_filter.py
@@ -6,6 +6,9 @@
     @license: GNU GPL, see COPYING for details.
 """
 
+import io
+import zipfile
+
 
 class TestFilters:
 
@@ -54,9 +57,19 @@ class TestFilters:
             fname = self.make_file(data)
             assert _filter(None, fname) == expected
 
+    def testOpenDocument(self):
+        from MoinMoin.filter.application_vnd_oasis_opendocument import execute as _filter
+
+        output = io.BytesIO()
+        with zipfile.ZipFile(output, 'w') as archive:
+            archive.writestr('content.xml', '<doc>Hello <b>Wörld</b></doc>'.encode('utf-8'))
+
+        fname = self.make_file(output.getvalue())
+        assert _filter(None, fname) == 'Hello Wörld'
+
 coverage_modules = ['MoinMoin.filter.text',
                     'MoinMoin.filter.text_html',
                     'MoinMoin.filter.text_xml',
                     'MoinMoin.filter.application_octet_stream',
+                    'MoinMoin.filter.application_vnd_oasis_opendocument',
                    ]
-

--- a/tests/parser/_tests/test_text_csv.py
+++ b/tests/parser/_tests/test_text_csv.py
@@ -18,7 +18,7 @@ PAGENAME = u'ThisPageDoesNotExistsAndWillNeverBeReally'
 class ParserTestCase:
     """ Helper class that provide a parsing method """
 
-    def parse(self, req, body):
+    def parse(self, req, body, **parser_kwargs):
         """Parse body and return html
 
         Create a page with body, then parse it and format using html formatter
@@ -34,7 +34,7 @@ class ParserTestCase:
         page.formatter = formatter
         request.page = page
         request.formatter = formatter
-        parser = CSV_Parser(body, request, line_anchors=False)
+        parser = CSV_Parser(body, request, line_anchors=False, **parser_kwargs)
         formatter.startContent('') # needed for _include_stack init
         output = request.redirectedOutput(parser.format, formatter)
         formatter.endContent('')
@@ -57,5 +57,9 @@ class TestDelimiters(ParserTestCase):
         result = self.parse(req, 'ABCDEFGHIJ')
         assert '<td class="hcolumn0"><strong>ABCDEFGHIJ</strong></td>' in  result
 
-coverage_modules = ['MoinMoin.parser.text_csv']
+    def test_format_arguments_are_text(self, req):
+        result = self.parse(req, 'left|right', format_args='separator=|')
+        assert '<strong>left</strong>' in result
+        assert '<strong>right</strong>' in result
 
+coverage_modules = ['MoinMoin.parser.text_csv']

--- a/tests/security/_tests/test_security.py
+++ b/tests/security/_tests/test_security.py
@@ -12,6 +12,7 @@
 import pytest
 
 from MoinMoin import security
+from MoinMoin.security.textcha import TextCha
 acliter = security.ACLStringIterator
 AccessControlList = security.AccessControlList
 
@@ -19,6 +20,16 @@ from MoinMoin.datastruct import ConfigGroups
 from MoinMoin.user import User
 
 from tests._tests import create_page, nuke_page, wikiconfig
+
+
+@pytest.mark.parametrize('secret', ['shared secret', b'shared secret'])
+def test_textcha_signature_accepts_text_and_byte_secrets(secret):
+    textcha = TextCha.__new__(TextCha)
+    textcha.secret = secret
+
+    assert textcha._compute_signature('What is 2 + 2?', 1234567890) == (
+        '91c29839c7fb295b70964ed86123e828620b16f1'
+    )
 
 
 class TestACLStringIterator:


### PR DESCRIPTION
## Summary

- normalize text and bytes at HMAC, password recovery, authentication, and password hashing boundaries
- replace Python 2-only hex and Base64 APIs with Python 3 equivalents
- use binary in-memory streams for ZIP, TAR, XSLT, and chart output
- fix text decoding in CSV, filters, migration tools, OpenID, and auxiliary actions
- add regression coverage for HMAC, IWID generation, authentication, archives, filters, CSV, and migration logs

## Testing

- `73 passed, 2 skipped, 1 xfailed` in the focused compatibility suite
- Ruff fatal/undefined-name checks pass for all changed Python files
- all changed Python files compile successfully
- full `pytest -q tests`: `407 passed, 73 skipped, 22 xfailed`; remaining `45 failed, 56 errors` are existing cache/context failures and missing optional Xapian support