### PR TITLE
Invalidate compiled page caches across Python runtimes

### DIFF
--- a/MoinMoin/Page.py
+++ b/MoinMoin/Page.py
@@ -34,8 +34,11 @@
 """
 
 import codecs
+import importlib.util
+import marshal
 import os
 import re
+import sys
 from logging import NOTSET
 
 from MoinMoin import config, caching, user, util, wikiutil
@@ -44,6 +47,30 @@ from MoinMoin.logfile import eventlog
 from MoinMoin.decorator import context_timer
 
 logging = log.getLogger(__name__)
+
+
+def _page_code_cache_header():
+    implementation = sys.implementation
+    version = implementation.version
+    runtime = '%s:%d.%d.%d:%s:%d:%s:%d' % (
+        implementation.name,
+        version.major,
+        version.minor,
+        version.micro,
+        version.releaselevel,
+        version.serial,
+        implementation.cache_tag or '',
+        marshal.version,
+    )
+    return (
+        b'MoinMoin.Page.code-cache\0' +
+        runtime.encode('ascii') +
+        b'\0' +
+        importlib.util.MAGIC_NUMBER
+    )
+
+
+_PAGE_CODE_CACHE_HEADER = _page_code_cache_header()
 
 
 def is_cache_exception(e):
@@ -1473,9 +1500,13 @@ class Page:
         if cache.needsUpdate(self._text_filename(), attachmentsPath):
             raise Exception('CacheNeedsUpdate')
 
-        import marshal
         try:
-            return marshal.loads(cache.content())
+            content = cache.content()
+            # Marshalled code objects are only valid for the runtime that
+            # created them.
+            if not content.startswith(_PAGE_CODE_CACHE_HEADER):
+                raise ValueError('incompatible page code cache')
+            return marshal.loads(content[len(_PAGE_CODE_CACHE_HEADER):])
         except (EOFError, ValueError, TypeError):
             # Bad marshal data, must update the cache.
             # See http://docs.python.org/lib/module-marshal.html
@@ -1487,7 +1518,6 @@ class Page:
 
     def makeCache(self, request, parser):
         """ Format content into code, update cache and return code """
-        import marshal
         from MoinMoin.formatter.text_python import Formatter
         formatter = Formatter(request, ["page"], self.formatter)
 
@@ -1502,7 +1532,7 @@ class Page:
         code = compile(src.encode(config.charset),
                        self.page_name.encode(config.charset), 'exec')
         cache = caching.CacheEntry(request, self, self.getFormatterName(), scope='item')
-        cache.update(marshal.dumps(code))
+        cache.update(_PAGE_CODE_CACHE_HEADER + marshal.dumps(code))
         return code
 
     def _specialPageText(self, request, special_type):

--- a/tests/_tests/test_Page.py
+++ b/tests/_tests/test_Page.py
@@ -7,11 +7,30 @@
 """
 
 
+import importlib.util
+import io
+import marshal
+import sys
 
-from MoinMoin.Page import Page
+from MoinMoin import caching
+from MoinMoin.Page import Page, _PAGE_CODE_CACHE_HEADER
 
 
 class TestPage:
+    def testCodeCacheHeaderIdentifiesRuntime(self):
+        implementation = sys.implementation
+        version = implementation.version
+
+        assert implementation.name.encode('ascii') in _PAGE_CODE_CACHE_HEADER
+        assert ('%d.%d.%d' % (
+            version.major,
+            version.minor,
+            version.micro,
+        )).encode('ascii') in _PAGE_CODE_CACHE_HEADER
+        if implementation.cache_tag:
+            assert implementation.cache_tag.encode('ascii') in _PAGE_CODE_CACHE_HEADER
+        assert _PAGE_CODE_CACHE_HEADER.endswith(importlib.util.MAGIC_NUMBER)
+
     def testMeta(self, req):
         page = Page(req, u'FrontPage')
         meta = page.meta
@@ -55,7 +74,6 @@ class TestPage:
 
     def testSendPage(self, req):
         page = Page(req, u"FrontPage")
-        import io
         out = io.StringIO()
         req.redirect(out)
         page.send_page(msg=u'Done', emit_headers=False)
@@ -64,6 +82,26 @@ class TestPage:
         del out
         assert result.strip().endswith('</html>')
         assert result.strip().startswith('<!DOCTYPE HTML PUBLIC')
+
+    def testSendPageRebuildsUnversionedCodeCache(self, req):
+        page = Page(req, u"FrontPage")
+        cache = caching.CacheEntry(req, page, 'text_html', scope='item')
+        stale_code = compile(
+            "raise RuntimeError('unversioned cache was executed')",
+            'stale-page-cache',
+            'exec',
+        )
+        cache.update(marshal.dumps(stale_code))
+
+        out = io.StringIO()
+        req.redirect(out)
+        try:
+            page.send_page(emit_headers=False)
+        finally:
+            req.redirect()
+
+        assert out.getvalue().strip().endswith('</html>')
+        assert cache.content().startswith(_PAGE_CODE_CACHE_HEADER)
 
 
 class TestRootPage:
@@ -76,4 +114,3 @@ class TestRootPage:
 
 
 coverage_modules = ['MoinMoin.Page']
-


### PR DESCRIPTION
## Summary

- prefix marshalled page code caches with a runtime fingerprint
- include the Python implementation/version, cache tag, marshal version, and bytecode magic number
- reject legacy or incompatible cache entries before unmarshalling and rebuild them through the existing `CacheNeedsUpdate` path
- add regression coverage proving an unversioned cache is never executed and is automatically replaced

## Rationale

Python code objects are not portable across interpreter versions. The previous cache format stored raw `marshal` output, so an interpreter upgrade could load stale bytecode and fail page rendering with `SystemError: unknown opcode`.

The cache filename remains unchanged, preserving refresh and cache timestamp behavior. Existing cache files are migrated lazily on first page access; deployment-time cache deletion is not required.

## Tests

- `pytest -q tests/_tests/test_Page.py`: 11 passed
- affected suite (`test_Page`, `test_caching`, formatter): 19 passed, 2 skipped, 1 xfailed
- `python3 -m py_compile MoinMoin/Page.py tests/_tests/test_Page.py`
- full `pytest -q tests`: 412 passed; 43 existing failures and 56 errors remain, primarily unrelated converter/search failures and the unavailable Xapian dependency. The previous page-cache `unknown opcode` failure is resolved.