### PR TITLE
Fix remaining Python 3 runtime incompatibilities

### DIFF
--- a/MoinMoin/auth/openidrp.py
+++ b/MoinMoin/auth/openidrp.py
@@ -206,10 +206,10 @@ username and leave the password field blank.""")))
         return MultistageFormLogin(assoc)
 
     def _handle_associate_continuation(self, request):
+        _ = request.getText
         if 'openid.id' not in request.session:
             return CancelLogin(_('No OpenID found in session.'))
 
-        _ = request.getText
         username = request.form.get('username', '')
         password = request.form.get('password', '')
         if not password:

--- a/MoinMoin/parser/text_rst.py
+++ b/MoinMoin/parser/text_rst.py
@@ -11,6 +11,7 @@
 import re
 import io
 import sys
+from types import MethodType
 
 # docutils imports are below
 from MoinMoin.parser.text_moin_wiki import Parser as WikiParser
@@ -208,7 +209,7 @@ Lists: * bullets; 1., a. numbered items.
     def __init__(self, raw, request, **kw):
         self.raw = raw
         self.request = request
-        self.form = request.form
+        self.form = request.request.form
 
     def format(self, formatter, **kw):
         # Create our simple parser
@@ -497,8 +498,8 @@ class MoinTranslator(html4css1.HTMLTranslator):
         }
         for rest_func, moin_func in list(handlers.items()):
             visit_func, depart_func = self.create_wiki_functor(moin_func)
-            visit_func = new.instancemethod(visit_func, self, MoinTranslator)
-            depart_func = new.instancemethod(depart_func, self, MoinTranslator)
+            visit_func = MethodType(visit_func, self)
+            depart_func = MethodType(depart_func, self)
             setattr(self, 'visit_%s' % (rest_func), visit_func)
             setattr(self, 'depart_%s' % (rest_func), depart_func)
 
@@ -547,8 +548,8 @@ class MoinTranslator(html4css1.HTMLTranslator):
         ]
         for adm in handled_admonitions:
             visit_func, depart_func = self.create_admonition_functor(adm)
-            visit_func = new.instancemethod(visit_func, self, MoinTranslator)
-            depart_func = new.instancemethod(depart_func, self, MoinTranslator)
+            visit_func = MethodType(visit_func, self)
+            depart_func = MethodType(depart_func, self)
             setattr(self, 'visit_%s' % (adm), visit_func)
             setattr(self, 'depart_%s' % (adm), depart_func)
 

--- a/MoinMoin/script/account/inactive.py
+++ b/MoinMoin/script/account/inactive.py
@@ -6,11 +6,17 @@ MoinMoin - find inactive users (and disable / remove them)
 @license: GNU GPL, see COPYING for details.
 """
 
-from past.builtins import execfile
-
 from MoinMoin.logfile import editlog
 from MoinMoin.script import MoinScript
 from MoinMoin.user import getUserList, User
+
+
+def _load_editlog_uids(filename):
+    namespace = {'editlog_uids': set()}
+    with open(filename, encoding='utf-8') as source_file:
+        source = source_file.read()
+    exec(compile(source, filename, 'exec'), {}, namespace)
+    return namespace['editlog_uids']
 
 
 class PluginScript(MoinScript):
@@ -96,12 +102,12 @@ General syntax: moin [options] account inactive [inactive-options]
             editlog_uids = set()
             for log in logs(request):
                 editlog_uids |= set(uids(log))
-            with open(fn, "a") as f:
+            with open(fn, "a", encoding='utf-8') as f:
                 for uid in editlog_uids:
                     u = User(request, uid)
                     code = u'editlog_uids.add(%r)  # %r %r %r\n' % (
                                uid, u.name, u.email, u.jid)
-                    f.write(code.encode('utf-8'))
+                    f.write(code)
 
         elif self.options.py_exec_file:
             def check_interactive(u):
@@ -112,9 +118,7 @@ General syntax: moin [options] account inactive [inactive-options]
                     return True
 
             fn = self.options.py_exec_file
-            locs = dict(editlog_uids=set())
-            execfile(fn, {}, locs)
-            editlog_uids = locs.get('editlog_uids')
+            editlog_uids = _load_editlog_uids(fn)
 
             profile_uids = set(getUserList(request))
 
@@ -130,4 +134,3 @@ General syntax: moin [options] account inactive [inactive-options]
                 elif self.options.remove:
                     if check_interactive(u):
                         u.remove()
-

--- a/MoinMoin/util/dataset.py
+++ b/MoinMoin/util/dataset.py
@@ -57,11 +57,14 @@ class Dataset:
         """
         self._pos = 0
 
+    def __iter__(self):
+        return self
+
     def __next__(self):
         """ Return next row as a tuple, ordered by columns.
         """
         if self._pos >= len(self):
-            return None
+            raise StopIteration
 
         row = self.data[self._pos]
         self._pos += 1
@@ -83,10 +86,9 @@ class DictDataset(Dataset):
     """
 
     def __next__(self):
-        row = Dataset.next(self)
-        return tuple([row[col.name] for col in self.columns])
+        row = super().__next__()
+        return tuple(row[col.name] for col in self.columns)
 
 
 class DbDataset(Dataset):
     pass
-

--- a/MoinMoin/widget/browser.py
+++ b/MoinMoin/widget/browser.py
@@ -6,6 +6,8 @@
                 2010 MoinMoin:EugeneSyromyatnikov
     @license: GNU GPL, see COPYING for details.
 """
+from itertools import chain
+
 from MoinMoin.widget import base
 from MoinMoin import wikiutil
 
@@ -128,21 +130,20 @@ class DataBrowserWidget(base.Widget):
             given by idx
         """
         self.data.reset()
-        row = next(self.data)
         # [empty] is a special already
         unique = ['']
 
         value = None
         name = '%sfilter%d' % (self.data_id, idx)
-        if name in self.request.values:
-            value = self.request.values.getlist(name)
-        while row:
+        values = self.request.request.values
+        if name in values:
+            value = values.getlist(name)
+        for row in self.data:
             option = row[idx]
             if isinstance(option, tuple):
                 option = option[1]
             if option not in unique:
                 unique.append(option)
-            row = next(self.data)
 
         # fill in the empty field we left blank
         del unique[0]
@@ -211,19 +212,25 @@ class DataBrowserWidget(base.Widget):
 
         # add data
         self.data.reset()
-        row = next(self.data)
-        if row is not None:
-            filters = [None] * len(row)
+        try:
+            first_row = next(self.data)
+        except StopIteration:
+            rows = ()
+            filters = []
+        else:
+            rows = chain((first_row,), self.data)
+            filters = [None] * len(first_row)
 
-            if havefilters:
-                for idx in range(len(row)):
-                    name = '%sfilter%d' % (self.data_id, idx)
-                    if name in self.request.values:
-                        filters[idx] = self.request.getlist(name)
-                        if filters[idx] == self._all:
-                            filters[idx] = None
+        if havefilters:
+            values = self.request.request.values
+            for idx in range(len(filters)):
+                name = '%sfilter%d' % (self.data_id, idx)
+                if name in values:
+                    filters[idx] = values.getlist(name)
+                    if filters[idx] == self._all:
+                        filters[idx] = None
 
-        while row:
+        for row in rows:
             hidden = False
 
             if havefilters:
@@ -256,8 +263,6 @@ class DataBrowserWidget(base.Widget):
                         result.append(str(row[idx]))
                     result.append(fmt.table_cell(0))
                 result.append(fmt.table_row(0))
-
-            row = next(self.data)
 
         result.append(fmt.table(0))
         result.append(fmt.div(0))

--- a/MoinMoin/wikisync.py
+++ b/MoinMoin/wikisync.py
@@ -394,10 +394,15 @@ class Tag:
     def __repr__(self):
         return u"<Tag normalised_pagename=%r remote_wiki=%r remote_rev=%r current_rev=%r>" % (getattr(self, "normalised_name", "UNDEF"), self.remote_wiki, self.remote_rev, self.current_rev)
 
-    def __cmp__(self, other):
+    def __eq__(self, other):
         if not isinstance(other, Tag):
             return NotImplemented
-        return cmp(self.current_rev, other.current_rev)
+        return self.current_rev == other.current_rev
+
+    def __lt__(self, other):
+        if not isinstance(other, Tag):
+            return NotImplemented
+        return self.current_rev < other.current_rev
 
 
 class AbstractTagStore:
@@ -518,4 +523,3 @@ class PickleTagStore(AbstractTagStore):
 # currently we just have one implementation, so we do not need
 # a factory method
 TagStore = PickleTagStore
-

--- a/MoinMoin/xmlrpc/WhoAmI.py
+++ b/MoinMoin/xmlrpc/WhoAmI.py
@@ -5,12 +5,12 @@
     @license: GNU GPL, see COPYING for details.
 """
 
-s
+
 def execute(xmlrpcobj, *args):
     request = xmlrpcobj.request
     username = request.user.name
     if not username:
         username = "<unknown user>"
     valid = request.user.valid
-    result = "You are %s. valid=%d." % (username.encode("utf-8"), valid)
+    result = "You are %s. valid=%d." % (username, valid)
     return xmlrpcobj._outstr(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ parsedatetime = "^2.6"
 flup = "^1.0"
 pygments = "^2.15"
 secure-cookie = "^0.2.0"
+python3-openid = { version = "^3.2", optional = true }
+
+[tool.poetry.extras]
+openid = ["python3-openid"]
 
 [tool.poetry.scripts]
 moin = "MoinMoin.script.moin:run"

--- a/tests/_tests/test_account_inactive.py
+++ b/tests/_tests/test_account_inactive.py
@@ -1,0 +1,17 @@
+"""
+    MoinMoin - inactive account script tests
+
+    @license: GNU GPL, see COPYING for details.
+"""
+
+from MoinMoin.script.account.inactive import _load_editlog_uids
+
+
+def test_load_editlog_uids_executes_utf8_source(tmp_path):
+    source = tmp_path / 'keep-users.py'
+    source.write_text(
+        "editlog_uids.add('123')\neditlog_uids.add('用户')\n",
+        encoding='utf-8',
+    )
+
+    assert _load_editlog_uids(str(source)) == {'123', '用户'}

--- a/tests/_tests/test_wikisync.py
+++ b/tests/_tests/test_wikisync.py
@@ -27,13 +27,14 @@ class TestUnsafeSync:
         tags = TagStore(self.page)
         assert not tags.get_all_tags()
         tags.add(remote_wiki="foo", remote_rev=1, current_rev=2, direction=BOTH, normalised_name="FrontPage")
+        tags.add(remote_wiki="foo", remote_rev=2, current_rev=3, direction=BOTH, normalised_name="FrontPage")
         tags = TagStore(self.page) # reload
         dummy = repr(tags.get_all_tags()) # this should not raise
         assert tags.get_all_tags()[0].remote_rev == 1
+        assert tags.get_last_tag().current_rev == 3
 
     def teardown_method(self, method):
         tags = TagStore(self.page)
         tags.clear()
 
 coverage_modules = ['MoinMoin.wikisync']
-

--- a/tests/auth/_tests/test_openidrp.py
+++ b/tests/auth/_tests/test_openidrp.py
@@ -1,0 +1,26 @@
+"""
+    MoinMoin - OpenID relying party tests
+
+    @license: GNU GPL, see COPYING for details.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip('openid')
+
+from MoinMoin.auth import CancelLogin
+from MoinMoin.auth.openidrp import OpenIDAuth
+
+
+def test_associate_continuation_without_openid_session():
+    request = SimpleNamespace(
+        session={},
+        getText=lambda text, **kwargs: text,
+    )
+
+    result = OpenIDAuth()._handle_associate_continuation(request)
+
+    assert isinstance(result, CancelLogin)
+    assert result.message == 'No OpenID found in session.'

--- a/tests/parser/_tests/test_text_rst.py
+++ b/tests/parser/_tests/test_text_rst.py
@@ -1,0 +1,23 @@
+"""
+    MoinMoin - reStructuredText parser tests
+
+    @license: GNU GPL, see COPYING for details.
+"""
+
+import pytest
+
+pytest.importorskip('docutils')
+
+from MoinMoin.Page import Page
+from MoinMoin.parser.text_rst import Parser
+
+
+def test_rst_handlers_are_bound_and_rendered(req):
+    page = Page(req, 'RstTestPage')
+    req.page = page
+    req.formatter.page = page
+    parser = Parser('This is **strong**.', req)
+
+    result = req.redirectedOutput(parser.format, req.formatter)
+
+    assert '<strong>strong</strong>' in result

--- a/tests/util/_tests/test_dataset.py
+++ b/tests/util/_tests/test_dataset.py
@@ -1,0 +1,30 @@
+"""
+    MoinMoin - dataset tests
+
+    @license: GNU GPL, see COPYING for details.
+"""
+
+import pytest
+
+from MoinMoin.util.dataset import Column, DictDataset, TupleDataset
+
+
+def test_tuple_dataset_iterator_protocol():
+    dataset = TupleDataset()
+    dataset.addRow(('first', 1))
+    dataset.addRow(('second', 2))
+
+    assert list(dataset) == [('first', 1), ('second', 2)]
+    with pytest.raises(StopIteration):
+        next(dataset)
+
+    dataset.reset()
+    assert next(dataset) == ('first', 1)
+
+
+def test_dict_dataset_orders_values_by_columns():
+    dataset = DictDataset()
+    dataset.columns = [Column('name'), Column('count')]
+    dataset.addRow({'count': 2, 'name': 'example'})
+
+    assert list(dataset) == [('example', 2)]

--- a/tests/widget/_tests/test_DataBrowserWidget.py
+++ b/tests/widget/_tests/test_DataBrowserWidget.py
@@ -101,3 +101,19 @@ class Test_DataBrowserWidget_sort_table:
         test_run = self.table.data.data
         result = [result[0] for result in test_run]
         assert result == ['L4', 'L1', 'L5', 'L2', 'L3']
+
+    def test_render_with_autofilter(self):
+        data = TupleDataset()
+        data.columns = [
+            Column('name', label='Name', autofilter=1),
+            Column('count', label='Count'),
+        ]
+        data.addRow(('L1', '1'))
+        data.addRow(('L5', '5'))
+        self.table.setData(data)
+
+        result = self.table.render()
+
+        assert '<table' in result
+        assert 'L1' in result
+        assert '<option value="L5">L5</option>' in result

--- a/tests/xmlrpc/_tests/test_xmlrpc.py
+++ b/tests/xmlrpc/_tests/test_xmlrpc.py
@@ -9,9 +9,11 @@
 
 
 
+from types import SimpleNamespace
 from xmlrpc.client import Fault
 
 from MoinMoin.xmlrpc import XmlRpcBase
+from MoinMoin.xmlrpc import WhoAmI
 
 
 def test_fault_serialization(req):
@@ -39,5 +41,13 @@ def test_getAuthToken(req):
     assert xmlrpc.xmlrpc_getAuthToken("Foo", "bar") == ""
 
 
-coverage_modules = ['MoinMoin.xmlrpc']
+def test_whoami_returns_unicode_username():
+    request = SimpleNamespace(
+        user=SimpleNamespace(name='Jörg', valid=True),
+    )
+    xmlrpc = SimpleNamespace(request=request, _outstr=lambda value: value)
 
+    assert WhoAmI.execute(xmlrpc) == 'You are Jörg. valid=1.'
+
+
+coverage_modules = ['MoinMoin.xmlrpc']


### PR DESCRIPTION
## Summary

- replace sync tag `__cmp__` with Python 3 rich comparison methods
- implement the standard Dataset iterator protocol and update DataBrowserWidget consumers
- fix DataBrowserWidget request access for autofilter rendering
- replace `new.instancemethod` with `types.MethodType` in the reStructuredText parser
- use the underlying request form in the RST parser
- restore the XML-RPC `WhoAmI` plugin and preserve Unicode usernames
- replace the `execfile` compatibility shim with native `compile`/`exec` and write inactive-user files as UTF-8 text
- fix the OpenID continuation gettext scope and expose `python3-openid` through an optional `openid` extra

## Tests

- P1 regression suite: 17 passed
- Dataset/DataBrowser integration suite covering CSV, statistics, attachments, and user administration: 17 passed
- full `pytest -q tests`: 419 passed, 43 failed, 56 errors, 73 skipped, 22 xfailed
  - failure/error counts are unchanged from `master`
  - the 56 errors remain the unavailable Xapian dependency
  - this PR adds seven passing tests
- `poetry check`
- modified modules compile under Python 3.13 and Python 3.14

Optional-path tests used `python3-openid 3.2.0` and `docutils 0.23`.