### PR TITLE
Fix Python 3.13 and 3.14 compatibility

### DIFF
--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -1,0 +1,56 @@
+name: Python compatibility
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: python-compat-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compatibility:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.13"
+          - "3.14"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install .
+
+      - name: Compile with strict syntax warnings
+        env:
+          PYTHONWARNINGS: error::SyntaxWarning
+        run: python -m compileall -q -f MoinMoin
+
+      - name: Run compatibility tests
+        run: |
+          pytest -q \
+            tests/_tests/test_user.py::TestLoginWithPassword::test_auth_with_des_stored_password \
+            tests/web/_tests/test_flup_frontend.py \
+            tests/util/_tests/test_lock.py \
+            tests/_tests/test_packages.py \
+            tests/macro/_tests/test_Action.py \
+            tests/_tests/test_account_inactive.py

--- a/MoinMoin/action/__init__.py
+++ b/MoinMoin/action/__init__.py
@@ -239,7 +239,7 @@ class ActionBase:
 
 # Builtin Actions ------------------------------------------------------------
 
-MIMETYPE_CRE = re.compile('[a-zA-Z0-9.+\-]{1,100}/[a-zA-Z0-9.+\-]{1,100}')
+MIMETYPE_CRE = re.compile(r'[a-zA-Z0-9.+\-]{1,100}/[a-zA-Z0-9.+\-]{1,100}')
 
 
 def do_raw(pagename, context):

--- a/MoinMoin/packages.py
+++ b/MoinMoin/packages.py
@@ -214,7 +214,7 @@ class ScriptEngine:
         from MoinMoin.version import release
         version_int = [int(x) for x in version.split(".")]
         # use a regex here to get only the numbers of the release string (e.g. ignore betaX)
-        release = re.compile('\d+').findall(release)[0:3]
+        release = re.compile(r'\d+').findall(release)[0:3]
         release = [int(x) for x in release]
         if version_int > release:
             if lines > 0:

--- a/MoinMoin/script/account/check.py
+++ b/MoinMoin/script/account/check.py
@@ -121,7 +121,7 @@ General syntax: moin [options] account check [check-options]
                     self.emails[u.email] = [uid]
 
             # collect account with no or invalid email address set:
-            if not u.email or not re.match(".*@.*\..*", u.email):
+            if not u.email or not re.match(r".*@.*\..*", u.email):
                 self.uids_noemail[uid] = u.name
 
     def hasmagicpage(self, uid):

--- a/MoinMoin/script/migration/text_moin158_wiki.py
+++ b/MoinMoin/script/migration/text_moin158_wiki.py
@@ -48,7 +48,7 @@ class Parser:
         'parent': r'(?:%s)?' % re.escape(PARENT_PREFIX),
     }
     url_rule = r'%(url_guard)s(%(url)s)\:([^\s\<%(punct)s]|([%(punct)s][^\s\<%(punct)s]))+' % {
-        'url_guard': u'(^|(?<!\w))',
+        'url_guard': r'(^|(?<!\w))',
         'url': url_pattern,
         'punct': punct_pattern,
     }
@@ -926,7 +926,7 @@ class Parser:
         scan_re = re.compile(rules, re.UNICODE)
         number_re = re.compile(self.ol_rule, re.UNICODE)
         term_re = re.compile(self.dl_rule, re.UNICODE)
-        indent_re = re.compile("^\s*", re.UNICODE)
+        indent_re = re.compile(r"^\s*", re.UNICODE)
         eol_re = re.compile(r'\r?\n', re.UNICODE)
         self.request.clock.stop('compile_huge_and_ugly')
 

--- a/MoinMoin/script/old/repair_language.py
+++ b/MoinMoin/script/old/repair_language.py
@@ -68,7 +68,7 @@ def listdir(path):
 
 
 def repairText(text):
-    """ Repair page text
+    r""" Repair page text
 
     We change only this type of lines that currently are in moinmaster
     ##language:\s*xx
@@ -159,7 +159,6 @@ if __name__ == '__main__':
         sys.exit(1)
 
     processPages(path, repair=options[sys.argv[1]])
-
 
 
 

--- a/MoinMoin/user.py
+++ b/MoinMoin/user.py
@@ -27,16 +27,13 @@ import os
 import time
 from copy import deepcopy
 
+from passlib.hash import des_crypt
+
 from MoinMoin import config, caching, wikiutil, i18n, events
 from MoinMoin import log
 from MoinMoin.support import md5crypt
 from MoinMoin.util import timefuncs, random_string
 from MoinMoin.wikiutil import url_quote_plus, safe_str_cmp
-
-try:
-    import crypt
-except ImportError:
-    crypt = None
 
 logging = log.getLogger(__name__)
 # for efficient lookup <attr> -> userid, we keep an index of this in the cache.
@@ -750,11 +747,9 @@ class User:
                         enc = md5crypt.unix_md5_crypt(password.encode('utf-8'),
                                                       salt.encode('ascii'))
                     elif scheme == '{DES}':
-                        if crypt is None:
-                            return False, False
                         # d is 2 characters salt + 11 characters hash
                         salt = d[:2]
-                        enc = crypt.crypt(password, salt).encode("utf8")
+                        enc = des_crypt.using(salt=salt).hash(password).encode("ascii")
 
                     else:
                         logging.error(

--- a/MoinMoin/util/lock.py
+++ b/MoinMoin/util/lock.py
@@ -235,12 +235,13 @@ class WriteLock(ExclusiveLock):
                         result = timer.haveTime()
                         break
                     timer.sleep()
-            finally:
-                if result:
-                    logging.debug('acquired write lock: %s' % self.lockDir)
-                    return True
-                else:
-                    self.release()
+            except BaseException:
+                self.release()
+                raise
+            if result:
+                logging.debug('acquired write lock: %s' % self.lockDir)
+                return True
+            self.release()
         return False
 
     # Private -------------------------------------------------------

--- a/MoinMoin/util/timefuncs.py
+++ b/MoinMoin/util/timefuncs.py
@@ -28,7 +28,7 @@ def formathttpdate(tmsecs=None):
     """
     stamp = formatdate(tmsecs, False)
     # replace non-standard "-0000" at end with http-mandated "GMT"
-    stamp = re.match('^(.*) [\-\+]0000$', stamp).group(1) + " GMT"
+    stamp = re.match(r'^(.*) [\-\+]0000$', stamp).group(1) + " GMT"
     return stamp
 
 

--- a/MoinMoin/web/flup_frontend.py
+++ b/MoinMoin/web/flup_frontend.py
@@ -24,6 +24,8 @@
 
 import os
 import sys
+import traceback
+from html import escape
 
 try:
     import flup.server.fcgi
@@ -43,6 +45,16 @@ from MoinMoin.web.frontend import ServerFrontEnd, FrontEnd, FrontEndNotAvailable
 from MoinMoin import log
 
 logging = log.getLogger(__name__)
+
+
+def format_web_error(exc_info):
+    """Return an HTML error page for the current exception."""
+    error = ''.join(traceback.format_exception(*exc_info))
+    return """<!DOCTYPE html>
+<html><head><title>Unhandled Exception</title></head>
+<body><h1>Unhandled Exception</h1><pre>%s</pre></body></html>
+""" % escape(error)
+
 
 if have_flup:
     class FlupFrontEnd(ServerFrontEnd):
@@ -89,9 +101,8 @@ if have_flup:
                     if self.debug == 'external':
                         raise
                     elif self.debug == 'web':
-                        import cgitb
                         req.stdout.write('Content-Type: text/html\r\n\r\n' +
-                                         cgitb.html(sys.exc_info()))
+                                         format_web_error(sys.exc_info()))
                     else:  # 'off'
                         errorpage = """<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
 <html><head>

--- a/tests/_tests/test_user.py
+++ b/tests/_tests/test_user.py
@@ -152,16 +152,12 @@ class TestLoginWithPassword:
         pw_hash = '{DES}gArsfn7O5Yqfo'
         self.createUser(req, name, pw_hash, True)
 
-        try:
-            import crypt
-            # Try to "login"
-            theuser = user.User(req, name=name, password=password)
-            assert theuser.valid
-            # Check if the stored password was auto-upgraded on login and saved
-            theuser = user.User(req, name=name, password=password)
-            assert theuser.enc_password.startswith(self.password_scheme)
-        except ImportError:
-            pytest.skip("Platform does not provide crypt module!")
+        # Try to "login"
+        theuser = user.User(req, name=name, password=password)
+        assert theuser.valid
+        # Check if the stored password was auto-upgraded on login and saved
+        theuser = user.User(req, name=name, password=password)
+        assert theuser.enc_password.startswith(self.password_scheme)
 
     def test_auth_with_sha_stored_password(self, req):
         """

--- a/tests/util/_tests/test_lock.py
+++ b/tests/util/_tests/test_lock.py
@@ -14,7 +14,7 @@ import time
 
 import pytest
 
-from MoinMoin.util.lock import ExclusiveLock
+from MoinMoin.util.lock import ExclusiveLock, WriteLock
 
 
 class TestExclusiveLock:
@@ -127,5 +127,20 @@ class TestExclusiveLock:
         time.sleep(delay)
         lock.release()
 
-coverage_modules = ['MoinMoin.util.lock']
 
+def test_write_lock_releases_exclusive_lock_on_error(tmp_path, monkeypatch):
+    lock_dir = str(tmp_path / 'lock')
+    lock = WriteLock(lock_dir)
+
+    def fail():
+        raise RuntimeError('read lock check failed')
+
+    monkeypatch.setattr(lock, '_expireReadLocks', fail)
+
+    with pytest.raises(RuntimeError, match='read lock check failed'):
+        lock.acquire(0.1)
+
+    assert not lock.isLocked()
+
+
+coverage_modules = ['MoinMoin.util.lock']

--- a/tests/web/_tests/test_flup_frontend.py
+++ b/tests/web/_tests/test_flup_frontend.py
@@ -1,0 +1,20 @@
+"""
+    MoinMoin - Flup frontend compatibility tests
+
+    @license: GNU GPL, see COPYING for details.
+"""
+
+import sys
+
+from MoinMoin.web import flup_frontend
+
+
+def test_format_web_error_uses_standard_traceback_and_escapes_html():
+    try:
+        raise RuntimeError('<script>alert("bad")</script>')
+    except RuntimeError:
+        page = flup_frontend.format_web_error(sys.exc_info())
+
+    assert 'RuntimeError' in page
+    assert '&lt;script&gt;' in page
+    assert '<script>' not in page


### PR DESCRIPTION
## Summary
- replace the removed `crypt` module with Passlib for legacy DES password verification while preserving automatic hash upgrades
- replace the removed `cgitb` module with an HTML-escaped standard traceback page for Flup web debugging
- fix invalid escape sequences and refactor the write-lock cleanup that Python 3.14 warns about
- add a Python 3.13/3.14 compatibility CI matrix with strict syntax-warning compilation

## Testing
- Python 3.13 compatibility suite: 23 passed
- Python 3.14 compatibility suite in a clean environment: 23 passed
- Python 3.14: `python -W error::SyntaxWarning -m compileall -q -f MoinMoin`
- Python 3.13 full suite: 431 passed, 43 failed, 56 errors, 72 skipped, 22 xfailed; the existing failure/error baseline is unchanged
- Python 3.14 full suite has the same 43 failures and 56 Xapian errors; optional OpenID/Docutils tests were skipped because those extras were not installed