### PR TITLE
Fix incomplete context and request migration

### DIFF
--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -53,4 +53,13 @@ jobs:
             tests/util/_tests/test_lock.py \
             tests/_tests/test_packages.py \
             tests/macro/_tests/test_Action.py \
-            tests/_tests/test_account_inactive.py
+            tests/_tests/test_account_inactive.py \
+            tests/web/_tests/test_contexts.py \
+            tests/_tests/test_Page.py::TestPage::testRequestCompatibilityAlias \
+            tests/action/_tests/test_cache.py \
+            tests/parser/_tests/test_unicode.py \
+            tests/search/_tests/test_search.py::TestMoinSearch \
+            tests/datastruct/backends/_tests/test_config_groups.py \
+            tests/datastruct/backends/_tests/test_composite_groups.py \
+            tests/datastruct/backends/_tests/test_wiki_groups.py \
+            tests/datastruct/backends/_tests/test_lazy_config_groups.py

--- a/MoinMoin/Page.py
+++ b/MoinMoin/Page.py
@@ -178,6 +178,7 @@ class Page:
         @keyword include_self: if 1, include current user (default: 0)
         """
         self.context = context
+        self.request = context  # Compatibility for legacy Page consumers.
         self.cfg = context.cfg
         self.page_name = page_name
         self.rev = kw.get('rev', 0)  # revision of this page

--- a/MoinMoin/web/contexts.py
+++ b/MoinMoin/web/contexts.py
@@ -177,6 +177,16 @@ class HTTPContext(BaseContext):
     cacheable = EnvironProxy('old.cacheable', 0)
     writestack = EnvironProxy('old.writestack', lambda o: list())
 
+    @property
+    def form(self):
+        """Expose submitted form data to legacy context consumers."""
+        return self.request.form
+
+    @property
+    def href(self):
+        """Expose the request URL builder to legacy context consumers."""
+        return self.request.href
+
     # methods regarding manipulation of HTTP related data
     def read(self, n=None):
         """ Read n bytes (or everything) from input stream. """

--- a/tests/_tests/test_Page.py
+++ b/tests/_tests/test_Page.py
@@ -17,6 +17,11 @@ from MoinMoin.Page import Page, _PAGE_CODE_CACHE_HEADER
 
 
 class TestPage:
+    def testRequestCompatibilityAlias(self, req):
+        page = Page(req, u'FrontPage')
+
+        assert page.request is req
+
     def testCodeCacheHeaderIdentifiesRuntime(self):
         implementation = sys.implementation
         version = implementation.version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,15 +91,16 @@ def pytest_funcarg__request(request):
 
 @pytest.fixture
 def req(request):
+    config_base = getattr(request.cls, 'Config', wikiconfig.Config)
     marker = request.node.get_closest_marker("wiki_config")
     if marker:
-        class config(wikiconfig.Config):
+        class config(config_base):
             pass
 
         for k, v in marker.kwargs.items():
             setattr(config, k, v)
     else:
-        config = wikiconfig.Config
+        config = config_base
 
     return init_test_request(config)
 

--- a/tests/datastruct/backends/_tests/__init__.py
+++ b/tests/datastruct/backends/_tests/__init__.py
@@ -15,10 +15,9 @@ from pytest import raises
 
 from MoinMoin import security
 from tests._tests import become_trusted, create_page, nuke_page
-from MoinMoin.datastruct import GroupDoesNotExistError, ConfigGroups
+from MoinMoin.datastruct import GroupDoesNotExistError
 
 
-@pytest.mark.wiki_config(groups=lambda s, r: ConfigGroups(r, GroupsBackendTest.test_groups))
 class GroupsBackendTest:
 
     test_groups = {u'EditorGroup': [u'AdminGroup', u'John', u'JoeDoe', u'Editor1', u'John'],

--- a/tests/datastruct/backends/_tests/test_lazy_config_groups.py
+++ b/tests/datastruct/backends/_tests/test_lazy_config_groups.py
@@ -13,7 +13,7 @@ from MoinMoin.datastruct import ConfigGroups, CompositeGroups
 from tests._tests import wikiconfig
 
 
-@pytest.mark.wiki_config(groups=lambda s, r: ConfigGroups(r, TestLazyConfigGroups.test_groups))
+@pytest.mark.wiki_config(groups=lambda s, r: ConfigLazyGroups(r, TestLazyConfigGroups.test_groups))
 class TestLazyConfigGroups(GroupsBackendTest):
 
     test_groups = {u'EditorGroup': [u'John', u'JoeDoe', u'Editor1'],

--- a/tests/datastruct/backends/_tests/test_wiki_groups.py
+++ b/tests/datastruct/backends/_tests/test_wiki_groups.py
@@ -12,10 +12,12 @@ import pytest
 
 from tests.datastruct.backends._tests import GroupsBackendTest
 from MoinMoin import security
+from MoinMoin.datastruct import WikiGroups
 from MoinMoin.user import User
 from tests._tests import append_page, become_trusted, create_page, create_random_string_list, nuke_page, nuke_user
 
 
+@pytest.mark.wiki_config(groups=lambda s, r: WikiGroups(r))
 class TestWikiGroupBackend(GroupsBackendTest):
 
     # Suppose that default configuration for the groups is used which

--- a/tests/web/_tests/test_contexts.py
+++ b/tests/web/_tests/test_contexts.py
@@ -1,0 +1,10 @@
+"""
+MoinMoin - web context compatibility tests
+
+@license: GNU GPL, see COPYING for details.
+"""
+
+
+def test_http_context_exposes_request_views(req):
+    assert req.form is req.request.form
+    assert req.href is req.request.href


### PR DESCRIPTION
## Summary
- expose legacy `form` and `href` request views explicitly on HTTP contexts
- restore the `Page.request` compatibility alias used by search expressions
- make the modern `req` fixture honor per-class test configuration
- run Wiki and lazy group tests against their intended backends
- extend the Python 3.13/3.14 compatibility workflow to cover these paths

## Verification
- Python 3.13 compatibility suite: 117 passed, 1 xfailed
- Python 3.14 compatibility suite: 117 passed, 1 xfailed
- Python 3.14 strict `SyntaxWarning` compilation passed
- Full Python 3.13 suite: 472 passed, 4 failed, 56 errors, 72 skipped, 22 xfailed

The four remaining failures are three unrelated converter regular-expression failures and one order-dependent search result count. The 56 errors still require the optional Xapian bindings.