### PR TITLE
Upgrade to Werkzeug 3 behind an HTTP facade

### DIFF
--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - "3.10"
           - "3.13"
           - "3.14"
 
@@ -54,6 +55,8 @@ jobs:
             tests/_tests/test_packages.py \
             tests/macro/_tests/test_Action.py \
             tests/_tests/test_account_inactive.py \
+            tests/web/_tests/test_http.py \
+            tests/web/_tests/test_session.py \
             tests/web/_tests/test_contexts.py \
             tests/_tests/test_Page.py::TestPage::testRequestCompatibilityAlias \
             tests/action/_tests/test_cache.py \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,9 +16,6 @@ recursive-include   MoinMoin/i18n *
 # include static htdocs
 recursive-include   MoinMoin/web/static/htdocs *
 
-# include non-py stuff from werkzeug
-recursive-include   MoinMoin/support/werkzeug/debug *
-
 # contrib stuff
 recursive-include   contrib *
 
@@ -38,4 +35,3 @@ global-exclude */.cvsignore
 # we distribute a uncompressed version, no need for that:
 global-exclude underlay.tar
 global-exclude README.underlay
-

--- a/MoinMoin/action/AttachFile.py
+++ b/MoinMoin/action/AttachFile.py
@@ -34,8 +34,6 @@ import time
 import zipfile
 from io import BytesIO
 
-from werkzeug.http import http_date
-
 from MoinMoin import config, packages
 from MoinMoin import log
 from MoinMoin import wikiutil
@@ -43,6 +41,7 @@ from MoinMoin.Page import Page
 from MoinMoin.events import FileAttachedEvent, FileRemovedEvent, send_event
 from MoinMoin.security.textcha import TextCha
 from MoinMoin.util import filesys
+from MoinMoin.web.http import http_date
 
 logging = log.getLogger(__name__)
 action_name = __name__.split('.')[-1]

--- a/MoinMoin/auth/__init__.py
+++ b/MoinMoin/auth/__init__.py
@@ -133,13 +133,10 @@
     @license: GNU GPL, see COPYING for details.
 """
 
-from werkzeug.exceptions import abort
-from werkzeug.urls import url_quote, url_quote_plus
-from werkzeug.utils import redirect
-
 from MoinMoin import log
 from MoinMoin import user, wikiutil
 from MoinMoin.util.abuse import log_attempt
+from MoinMoin.web.http import abort, redirect, url_quote, url_quote_plus
 from MoinMoin.web.utils import check_surge_protect
 
 logging = log.getLogger(__name__)

--- a/MoinMoin/auth/http.py
+++ b/MoinMoin/auth/http.py
@@ -88,8 +88,7 @@ class HTTPAuthMoin(BaseAuth):
             logging.debug("user: %r" % u)
 
         if not u or not u.valid:
-            from werkzeug.wrappers import Response
-            from werkzeug.exceptions import abort
+            from MoinMoin.web.http import Response, abort
             response = Response(_('Please log in first.'), 401,
                                 {'WWW-Authenticate': 'Basic realm="%s"' % self.realm})
             abort(response)

--- a/MoinMoin/converter/text_html_text_moin_wiki.py
+++ b/MoinMoin/converter/text_html_text_moin_wiki.py
@@ -14,8 +14,8 @@ from xml.dom import Node
 
 from MoinMoin import config, wikiutil
 from MoinMoin.error import ConvertError
-from werkzeug.urls import url_decode
 from MoinMoin.parser.text_moin_wiki import Parser as WikiParser
+from MoinMoin.web.http import url_decode
 interwiki_re = re.compile(WikiParser.interwiki_rule, re.VERBOSE|re.UNICODE)
 
 
@@ -1457,4 +1457,3 @@ def convert(request, pagename, text):
     text = convert_tree(request, pagename).do(tree)
     text = '\n'.join([s.rstrip() for s in text.splitlines()] + ['']) # remove trailing blanks
     return text
-

--- a/MoinMoin/web/__init__.py
+++ b/MoinMoin/web/__init__.py
@@ -5,7 +5,7 @@
     This package contains everything related to interfacing the wiki with
     the actual request from the web. It replaces the former packages
     `MoinMoin.request` and `MoinMoin.server`. There is code for convenient
-    access to the supplied request parameters (using the werkzeug library),
+    access to the supplied request parameters (through MoinMoin.web.http),
     wrappers (called contexts) that try to capture the use of the former
     Request-objects in MoinMoin, session handling and interfaces to
     common webserver deployment methods.
@@ -18,7 +18,7 @@ def _fixup_deps():
     """
     Alter the system path to import some 3rd party dependencies from
     inside the MoinMoin.support package. This is meant for deps
-    used inside this package, which are mainly werkzeug and flup.
+    used inside this package.
     """
     import sys, os
     from MoinMoin import support

--- a/MoinMoin/web/contexts.py
+++ b/MoinMoin/web/contexts.py
@@ -12,11 +12,6 @@ import sys
 import time
 import warnings
 
-from werkzeug.datastructures import Headers, HeaderSet
-from werkzeug.exceptions import abort, Unauthorized, NotFound
-from werkzeug.test import create_environ
-from werkzeug.utils import redirect
-
 from MoinMoin import auth
 from MoinMoin import i18n, user, config
 from MoinMoin import log
@@ -30,6 +25,15 @@ from MoinMoin.theme import load_theme_fallback
 from MoinMoin.util.abuse import log_attempt
 from MoinMoin.util.clock import Clock
 from MoinMoin.web.exceptions import Forbidden, SurgeProtection
+from MoinMoin.web.http import (
+    HeaderSet,
+    Headers,
+    NotFound,
+    Unauthorized,
+    abort,
+    create_environ,
+    redirect,
+)
 from MoinMoin.web.request import Request, MoinMoinFinish
 from MoinMoin.web.request import ResponseBase
 from MoinMoin.web.utils import UniqueIDGenerator

--- a/MoinMoin/web/exceptions.py
+++ b/MoinMoin/web/exceptions.py
@@ -7,7 +7,7 @@
     @license: GNU GPL, see COPYING for details.
 """
 
-from werkzeug import exceptions
+from MoinMoin.web.http import exceptions
 
 HTTPException = exceptions.HTTPException
 
@@ -27,13 +27,8 @@ class SurgeProtection(exceptions.ServiceUnavailable):
     )
 
     def __init__(self, description=None, retry_after=3600):
-        exceptions.ServiceUnavailable.__init__(self, description)
-        self.retry_after = retry_after
-
-    def get_headers(self, environ, scope):
-        headers = exceptions.ServiceUnavailable.get_headers(self, environ)
-        headers.append(('Retry-After', '%d' % self.retry_after))
-        return headers
+        exceptions.ServiceUnavailable.__init__(
+            self, description, retry_after=retry_after)
 
 
 class Forbidden(exceptions.Forbidden):

--- a/MoinMoin/web/http.py
+++ b/MoinMoin/web/http.py
@@ -1,0 +1,150 @@
+"""
+MoinMoin HTTP compatibility facade.
+
+Application code imports HTTP primitives from this module so Werkzeug API
+changes stay isolated at the WSGI boundary.
+"""
+
+from collections.abc import Mapping
+from urllib.parse import (
+    quote,
+    quote_from_bytes,
+    quote_plus,
+    unquote_to_bytes,
+    urlencode,
+    urljoin,
+    urlsplit,
+)
+from wsgiref.util import request_uri
+
+from werkzeug import Request, Response, exceptions
+from werkzeug.datastructures import (
+    EnvironHeaders,
+    Headers,
+    HeaderSet,
+    MultiDict,
+)
+from werkzeug.exceptions import (
+    NotFound,
+    Unauthorized,
+    abort,
+)
+from werkzeug.formparser import parse_form_data
+from werkzeug.http import http_date
+from werkzeug.middleware.shared_data import SharedDataMiddleware
+from werkzeug.serving import WSGIRequestHandler, run_simple
+from werkzeug.test import Client, EnvironBuilder, create_environ
+from werkzeug.utils import cached_property, redirect
+from werkzeug.wrappers import ResponseStream
+
+
+def url_quote(value, charset="utf-8", errors="strict", safe="/:"):
+    """Quote text or bytes using the legacy Werkzeug URL helper contract."""
+    if not isinstance(value, (str, bytes, bytearray)):
+        value = str(value)
+    if isinstance(value, str):
+        return quote(value, safe=safe, encoding=charset, errors=errors)
+    return quote_from_bytes(bytes(value), safe=safe)
+
+
+def url_quote_plus(value, charset="utf-8", errors="strict", safe=""):
+    """Quote a query-string component using spaces as plus signs."""
+    if not isinstance(value, (str, bytes, bytearray)):
+        value = str(value)
+    if isinstance(value, str):
+        return quote_plus(value, safe=safe, encoding=charset, errors=errors)
+    return quote_plus(bytes(value), safe=safe)
+
+
+def url_unquote(value, charset="utf-8", errors="replace"):
+    """Unquote a URL component and decode it with the requested charset."""
+    return unquote_to_bytes(value).decode(charset, errors)
+
+
+def _iter_multi_items(values):
+    if isinstance(values, MultiDict):
+        yield from values.items(multi=True)
+        return
+    if isinstance(values, Mapping):
+        values = values.items()
+    for key, value in values:
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                yield key, item
+        else:
+            yield key, value
+
+
+def url_encode(values, charset="utf-8", sort=False, key=None, separator="&"):
+    """Encode a mapping or multi-value mapping as a query string."""
+    items = [
+        (item_key, value)
+        for item_key, value in _iter_multi_items(values)
+        if value is not None
+    ]
+    if sort:
+        items.sort(key=key)
+    return urlencode(
+        items,
+        doseq=False,
+        encoding=charset,
+        errors="strict",
+    ).replace("&", separator)
+
+
+def _decode_query_component(value, charset, errors):
+    if isinstance(value, str):
+        value = value.replace("+", " ")
+    else:
+        value = value.replace(b"+", b" ")
+    return unquote_to_bytes(value).decode(charset, errors)
+
+
+def url_decode(value, charset="utf-8", include_empty=True,
+               errors="replace", separator="&", cls=MultiDict):
+    """Decode a query string while preserving repeated parameter names."""
+    if isinstance(value, bytes):
+        separator = separator.encode("ascii")
+    result = cls()
+    for pair in value.split(separator):
+        if not pair:
+            continue
+        equals = b"=" if isinstance(pair, bytes) else "="
+        if equals in pair:
+            item_key, item_value = pair.split(equals, 1)
+        else:
+            if not include_empty:
+                continue
+            item_key, item_value = pair, pair[:0]
+        result.add(
+            _decode_query_component(item_key, charset, errors),
+            _decode_query_component(item_value, charset, errors),
+        )
+    return result
+
+
+def get_current_url(environ):
+    """Return the full request URL for a WSGI environment."""
+    return request_uri(environ, include_query=True)
+
+
+class PathInfoFromRequestUriFix:
+    """Recover UTF-8 path bytes from a server's raw request URI."""
+
+    def __init__(self, application):
+        self.application = application
+
+    def __call__(self, environ, start_response):
+        for key in ("REQUEST_URL", "REQUEST_URI", "UNENCODED_URL", "RAW_URI"):
+            request_url = environ.get(key)
+            if not request_url:
+                continue
+            path = unquote_to_bytes(urlsplit(request_url).path).decode("latin-1")
+            script_name = environ.get("SCRIPT_NAME", "")
+            if path.startswith(script_name):
+                environ["PATH_INFO"] = path[len(script_name):]
+                break
+        return self.application(environ, start_response)
+
+
+url_join = urljoin

--- a/MoinMoin/web/profile.py
+++ b/MoinMoin/web/profile.py
@@ -17,9 +17,8 @@
     @copyright: 2008 MoinMoin:FlorianKrupicka,
     @license: GNU GPL, see COPYING for details.
 """
-from werkzeug.wsgi import get_current_url
-
 from MoinMoin import log
+from MoinMoin.web.http import get_current_url
 
 logging = log.getLogger(__name__)
 

--- a/MoinMoin/web/request.py
+++ b/MoinMoin/web/request.py
@@ -5,19 +5,23 @@
     @license: GNU GPL, see COPYING for details.
 """
 import sys
-from io import StringIO
+from io import BytesIO
 
 from passlib.utils import to_unicode
-from werkzeug import Request as RequestBase
-from werkzeug import Response as WerkzeugResponseBase
-from werkzeug.datastructures import EnvironHeaders
-from werkzeug.test import create_environ
-from werkzeug.urls import url_encode, url_join, url_quote
-from werkzeug.utils import cached_property
-from werkzeug.wrappers import ResponseStream
 
 from MoinMoin import config
 from MoinMoin import log
+from MoinMoin.web.http import (
+    EnvironHeaders,
+    Request as RequestBase,
+    Response as WerkzeugResponseBase,
+    ResponseStream,
+    cached_property,
+    create_environ,
+    url_encode,
+    url_join,
+    url_quote,
+)
 
 logging = log.getLogger(__name__)
 
@@ -185,8 +189,9 @@ class TestRequest(Request):
         if form_data is not None:
             form_data = url_encode(form_data)
             content_type = 'application/x-www-form-urlencoded'
+            form_data = form_data.encode(config.charset)
             content_length = len(form_data)
-            input_stream = StringIO(form_data)
+            input_stream = BytesIO(form_data)
         environ = create_environ(path=path, query_string=query_string,
                                  method=method, input_stream=input_stream,
                                  content_type=content_type,

--- a/MoinMoin/web/serving.py
+++ b/MoinMoin/web/serving.py
@@ -9,13 +9,8 @@
 """
 import os
 
-# make werkzeug use our logging framework and configuration:
-import werkzeug._internal
-from werkzeug.serving import run_simple, WSGIRequestHandler
-
 from MoinMoin import version, log
-
-werkzeug._internal._logger = log.getLogger('werkzeug')
+from MoinMoin.web.http import run_simple, WSGIRequestHandler
 
 logging = log.getLogger(__name__)
 

--- a/MoinMoin/web/session.py
+++ b/MoinMoin/web/session.py
@@ -11,9 +11,12 @@
                 2009 MoinMoin:ThomasWaldmann
     @license: GNU GPL, see COPYING for details.
 """
+import os
+import pickle
+import re
+import secrets
+import tempfile
 import time
-
-from secure_cookie.session import Session, FilesystemSessionStore
 
 from MoinMoin import config
 from MoinMoin.util import filesys
@@ -22,15 +25,172 @@ from MoinMoin import log
 logging = log.getLogger(__name__)
 
 
-class MoinSession(Session):
-    """ Compatibility interface to Werkzeug-sessions for old Moin-code.
+_missing = object()
+_session_id_re = re.compile(r'^[a-f0-9]{40}$')
+_transaction_suffix = '.__session'
+
+
+class MoinSession(dict):
+    """Server-side session dictionary that tracks direct changes.
 
         is_new is DEPRECATED and will go away soon.
     """
+    def __init__(self, data, sid, new=False):
+        dict.__init__(self, data)
+        self.sid = sid
+        self.new = new
+        self.modified = False
+
+    def __setitem__(self, key, value):
+        dict.__setitem__(self, key, value)
+        self.modified = True
+
+    def __delitem__(self, key):
+        dict.__delitem__(self, key)
+        self.modified = True
+
+    def clear(self):
+        dict.clear(self)
+        self.modified = True
+
+    def pop(self, key, default=_missing):
+        if default is _missing:
+            value = dict.pop(self, key)
+        else:
+            value = dict.pop(self, key, default)
+        self.modified = True
+        return value
+
+    def popitem(self):
+        value = dict.popitem(self)
+        self.modified = True
+        return value
+
+    def setdefault(self, key, default=None):
+        if key not in self:
+            self.modified = True
+        return dict.setdefault(self, key, default)
+
+    def update(self, *args, **kwargs):
+        dict.update(self, *args, **kwargs)
+        self.modified = True
+
+    def __ior__(self, values):
+        self.update(values)
+        return self
+
+    @property
+    def should_save(self):
+        return self.modified
+
+    def __repr__(self):
+        return "<%s %s%s>" % (
+            self.__class__.__name__,
+            dict.__repr__(self),
+            "*" if self.should_save else "",
+        )
+
     def _get_is_new(self):
         logging.warning("Deprecated use of MoinSession.is_new, please use .new")
         return self.new
     is_new = property(_get_is_new)
+
+
+class FilesystemSessionStore:
+    """Persist sessions using the historical Moin pickle file format."""
+
+    def __init__(self, path=None,
+                 filename_template='secure_cookie_%s.session',
+                 session_class=MoinSession, renew_missing=False, mode=0o644):
+        if path is None:
+            path = tempfile.gettempdir()
+        if filename_template.count('%s') != 1:
+            raise ValueError("filename_template must contain exactly one %s")
+        if filename_template.endswith(_transaction_suffix):
+            raise ValueError(
+                "filename_template may not end with %s" %
+                _transaction_suffix)
+        self.path = path
+        self.filename_template = filename_template
+        self.session_class = session_class
+        self.renew_missing = renew_missing
+        self.mode = mode
+
+    @staticmethod
+    def is_valid_key(key):
+        return (
+            isinstance(key, str) and
+            _session_id_re.fullmatch(key) is not None
+        )
+
+    @staticmethod
+    def generate_key():
+        return secrets.token_hex(20)
+
+    def get_session_filename(self, sid):
+        return os.path.join(self.path, self.filename_template % sid)
+
+    def new(self):
+        return self.session_class({}, self.generate_key(), True)
+
+    def get(self, sid):
+        if not self.is_valid_key(sid):
+            return self.new()
+        try:
+            with open(self.get_session_filename(sid), 'rb') as session_file:
+                data = pickle.load(session_file)
+        except OSError:
+            if self.renew_missing:
+                return self.new()
+            data = {}
+        except Exception:
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+        return self.session_class(data, sid, False)
+
+    def save(self, session):
+        if not self.is_valid_key(session.sid):
+            raise ValueError("invalid session id")
+        filename = self.get_session_filename(session.sid)
+        fd, temporary = tempfile.mkstemp(
+            suffix=_transaction_suffix, dir=self.path)
+        try:
+            with os.fdopen(fd, 'wb') as session_file:
+                pickle.dump(
+                    dict(session), session_file, pickle.HIGHEST_PROTOCOL)
+            os.replace(temporary, filename)
+            os.chmod(filename, self.mode)
+        except OSError:
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+        except Exception:
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+            raise
+
+    def delete(self, session):
+        try:
+            os.unlink(self.get_session_filename(session.sid))
+        except OSError:
+            pass
+
+    def list(self):
+        before, after = self.filename_template.split('%s', 1)
+        filename_re = re.compile(
+            r'%s(.{5,})%s$' % (re.escape(before), re.escape(after)))
+        result = []
+        for filename in os.listdir(self.path):
+            if filename.endswith(_transaction_suffix):
+                continue
+            match = filename_re.fullmatch(filename)
+            if match is not None:
+                result.append(match.group(1))
+        return result
 
 
 class SessionService:
@@ -128,9 +288,8 @@ class FileSessionService(SessionService):
     """
     This sample session service stores session information in a temporary
     directory and identifies the session via a cookie in the request/response
-    cycle. It is based on werkzeug's FilesystemSessionStore, that implements
-    the whole logic for creating the actual session objects (which are
-    inherited from the builtin `dict`)
+    cycle. Session files retain their historical pickle format, so existing
+    sessions remain readable after upgrading.
     """
     def __init__(self, cookie_usage='SESSION'):
         self.cookie_usage = cookie_usage
@@ -264,4 +423,3 @@ class FileSessionService(SessionService):
             # we killed the cookie (see above), so we can kill the session store, too
             logging.debug("destroying session: %r" % session)
             self.destroy_session(context, session)
-

--- a/MoinMoin/web/static/__init__.py
+++ b/MoinMoin/web/static/__init__.py
@@ -49,8 +49,7 @@
 from os.path import join, abspath, dirname, isdir
 
 from MoinMoin import config
-
-from werkzeug.middleware.shared_data import SharedDataMiddleware
+from MoinMoin.web.http import SharedDataMiddleware
 
 STATIC_FILES_PATH = join(abspath(dirname(__file__)), 'htdocs')
 
@@ -77,4 +76,3 @@ def make_static_serving_app(application, shared):
         else:
             raise ValueError("Invalid path given for shared parameter")
     return SharedDataMiddleware(application, shared)
-

--- a/MoinMoin/web/static/htdocs/applets/FCKeditor/editor/filemanager/connectors/py/fckconnector.py
+++ b/MoinMoin/web/static/htdocs/applets/FCKeditor/editor/filemanager/connectors/py/fckconnector.py
@@ -29,7 +29,7 @@ import os
 import sys
 from urllib.parse import parse_qs
 
-from werkzeug.formparser import parse_form_data
+from MoinMoin.web.http import parse_form_data
 
 from fckcommands import *  # default command's implementation
 

--- a/MoinMoin/web/utils.py
+++ b/MoinMoin/web/utils.py
@@ -7,15 +7,12 @@
 """
 import time
 
-from werkzeug.utils import redirect
-from werkzeug.exceptions import abort
-from werkzeug.wrappers import Response
-
 from MoinMoin import caching
 from MoinMoin import log
 from MoinMoin import wikiutil
 from MoinMoin.Page import Page
 from MoinMoin.web.exceptions import Forbidden, SurgeProtection
+from MoinMoin.web.http import Response, abort, redirect
 
 logging = log.getLogger(__name__)
 

--- a/MoinMoin/wikiutil.py
+++ b/MoinMoin/wikiutil.py
@@ -20,11 +20,15 @@ import urllib.parse
 import urllib.request
 from inspect import isfunction, isclass, ismethod, getfullargspec
 
-import werkzeug
-import werkzeug.urls
-
 from MoinMoin import config
 from MoinMoin import log
+from MoinMoin.web.http import (
+    url_decode,
+    url_encode,
+    url_quote as http_url_quote,
+    url_quote_plus as http_url_quote_plus,
+    url_unquote as http_url_unquote,
+)
 from MoinMoin.util import pysupport, lock
 
 logging = log.getLogger(__name__)
@@ -114,25 +118,25 @@ def decodeUserInput(s, charsets=[config.charset]):
 
 
 def url_quote(s, safe='/', want_unicode=None):
-    """ see werkzeug.urls.url_quote, we use a different safe param default value """
+    """Quote a URL component, using a different default safe set."""
     try:
         assert want_unicode is None
     except AssertionError:
         log.exception("call with deprecated want_unicode param, please fix caller")
-    return werkzeug.urls.url_quote(s, charset=config.charset, safe=safe)
+    return http_url_quote(s, charset=config.charset, safe=safe)
 
 
 def url_quote_plus(s, safe='/', want_unicode=None):
-    """ see werkzeug.urls.url_quote_plus, we use a different safe param default value """
+    """Quote a query component, using a different default safe set."""
     try:
         assert want_unicode is None
     except AssertionError:
         log.exception("call with deprecated want_unicode param, please fix caller")
-    return werkzeug.urls.url_quote_plus(s, charset=config.charset, safe=safe)
+    return http_url_quote_plus(s, charset=config.charset, safe=safe)
 
 
 def url_unquote(s, want_unicode=None):
-    """ see werkzeug.urls.url_unquote """
+    """Unquote a URL component."""
     try:
         assert want_unicode is None
     except AssertionError:
@@ -140,13 +144,13 @@ def url_unquote(s, want_unicode=None):
     if isinstance(s, str):
         s = s.encode(config.charset)
     try:
-        return werkzeug.urls.url_unquote(s, charset=config.charset, errors='strict')
+        return http_url_unquote(s, charset=config.charset, errors='strict')
     except UnicodeDecodeError:
-        return werkzeug.urls.url_unquote(s, charset='iso-8859-1', errors='replace')
+        return http_url_unquote(s, charset='iso-8859-1', errors='replace')
 
 
 def parseQueryString(qstr, want_unicode=None):
-    """ see werkzeug.urls.url_decode
+    """Decode a query string into a multi-value mapping.
 
         Please note: this returns a MultiDict, you might need to use .to_dict() on
                      the result if your code expects a "normal" dict.
@@ -156,11 +160,11 @@ def parseQueryString(qstr, want_unicode=None):
     except AssertionError:
         log.exception("call with deprecated want_unicode param, please fix caller")
     try:
-        return werkzeug.urls.url_decode(qstr, charset=config.charset, errors='strict',
-                                        include_empty=False)
+        return url_decode(qstr, charset=config.charset, errors='strict',
+                          include_empty=False)
     except UnicodeDecodeError:
-        return werkzeug.urls.url_decode(qstr, charset='iso-8859-1', errors='replace',
-                                        include_empty=False)
+        return url_decode(qstr, charset='iso-8859-1', errors='replace',
+                          include_empty=False)
 
 
 def makeQueryString(qstr=None, want_unicode=None, **kw):
@@ -169,8 +173,6 @@ def makeQueryString(qstr=None, want_unicode=None, **kw):
     kw arguments overide values in qstr.
 
     If a string is passed in, it's returned verbatim and keyword parameters are ignored.
-
-    See also: werkzeug.urls.url_encode
 
     @param qstr: dict to format as query string, using either ascii or unicode
     @param kw: same as dict when using keywords, using ascii or unicode
@@ -187,7 +189,7 @@ def makeQueryString(qstr=None, want_unicode=None, **kw):
         return qstr
     if isinstance(qstr, dict):
         qstr.update(kw)
-        return werkzeug.urls.url_encode(qstr, charset=config.charset)
+        return url_encode(qstr, charset=config.charset)
     else:
         raise ValueError("Unsupported argument type, should be dict.")
 
@@ -204,9 +206,7 @@ def quoteWikinameURL(pagename, charset=config.charset):
     @rtype: string
     @return: the quoted filename, all unsafe characters encoded
     """
-    # XXX please note that urllib.quote and werkzeug.urls.url_quote have
-    # XXX different defaults for safe=...
-    return werkzeug.urls.url_quote(pagename, charset=charset, safe='/')
+    return http_url_quote(pagename, charset=charset, safe='/')
 
 
 def escape(s, quote=None):

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ MoinMoin
 
 MoinMoin is a wiki engine - a software you can use to run your own wiki site.
 
-This is a fork of MoinMoin 1.x that runs on Python 3.x
+This is a fork of MoinMoin 1.x that runs on Python 3.10 and newer.
 
 Documentation
 =============

--- a/docs/REQUIREMENTS
+++ b/docs/REQUIREMENTS
@@ -105,14 +105,9 @@ minimum: 0.8.7(?)
 
 werkzeug (WSGI toolkit)
 =======================
-shipped: 1.0.1
-minimum: 1.0.0
+minimum: 3.1.8
 
-
-secure-cookie
-=============
-shipped: 0.1.0
-minimum: 0.1.0
+MoinMoin provides its own filesystem session store.
 
 
 xappy (High-Level Python library for Xapian)
@@ -146,4 +141,3 @@ required: see shipped
 D) MoinMoin/web/static/htdocs/applets/anywikidraw/
 shipped: 0.14
 required: 0.14
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,16 +6,15 @@ authors = ["Zhongke Chen <ch3n2k@gmail.com>"]
 packages = [{ include = "MoinMoin" }]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 pytest = "^7.2"
 passlib = "^1.7"
 future = "^0.18"
 html-sanitizer = "^2.6"
-werkzeug = "^2.2.3"
+werkzeug = "^3.1.8"
 parsedatetime = "^2.6"
 flup = "^1.0"
 pygments = "^2.15"
-secure-cookie = "^0.2.0"
 python3-openid = { version = "^3.2", optional = true }
 
 [tool.poetry.extras]

--- a/tests/_tests/test_fckeditor_connector.py
+++ b/tests/_tests/test_fckeditor_connector.py
@@ -10,7 +10,8 @@ from pathlib import Path
 import sys
 
 import pytest
-from werkzeug.test import EnvironBuilder
+
+from MoinMoin.web.http import EnvironBuilder
 
 
 CONNECTOR_DIR = (

--- a/tests/_tests/test_wikiutil.py
+++ b/tests/_tests/test_wikiutil.py
@@ -11,7 +11,7 @@ import pytest
 
 from MoinMoin import config, wikiutil
 
-from werkzeug.datastructures import MultiDict
+from MoinMoin.web.http import MultiDict
 
 
 class TestQueryStringSupport:
@@ -1092,4 +1092,3 @@ class TestVersion:
 
 
 coverage_modules = ['MoinMoin.wikiutil']
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,8 @@ import os.path
 import sys
 
 import pytest
-from werkzeug.test import Client
 
+from MoinMoin.web.http import Client
 from MoinMoin.web.contexts import AllContext
 from MoinMoin.web.request import TestRequest
 from MoinMoin.wsgiapp import Application

--- a/tests/web/_tests/test_http.py
+++ b/tests/web/_tests/test_http.py
@@ -1,0 +1,140 @@
+"""
+MoinMoin HTTP facade compatibility tests.
+
+@license: GNU GPL, see COPYING for details.
+"""
+
+import ast
+from base64 import b64encode
+from pathlib import Path
+
+from MoinMoin.web.exceptions import SurgeProtection
+from MoinMoin.web.http import (
+    Client,
+    MultiDict,
+    PathInfoFromRequestUriFix,
+    Response,
+    url_decode,
+    url_encode,
+    url_quote,
+    url_unquote,
+)
+from MoinMoin.web.request import Href, TestRequest as MoinTestRequest
+from MoinMoin.web.static import make_static_serving_app
+
+
+def test_url_helpers_preserve_legacy_query_semantics():
+    values = MultiDict([
+        ('name', 'Jürgen'),
+        ('tag', 'one'),
+        ('tag', 'two'),
+        ('ignored', None),
+    ])
+
+    encoded = url_encode(values)
+
+    assert encoded == 'name=J%C3%BCrgen&tag=one&tag=two'
+    assert url_decode(encoded).getlist('tag') == ['one', 'two']
+    assert url_decode('flag&empty=', include_empty=False) == MultiDict([
+        ('empty', ''),
+    ])
+    assert url_unquote(url_quote('Ärger')) == 'Ärger'
+    assert url_quote('http://example.org/a?b=1') == (
+        'http://example.org/a%3Fb%3D1')
+
+
+def test_href_uses_internal_url_helpers():
+    href = Href('/wiki', sort=True)
+
+    assert href('Ärger', tag=['one', 'two']) == (
+        '/wiki/%C3%84rger?tag=one&tag=two')
+    assert href('OtherWiki:Page') == '/wiki/OtherWiki:Page'
+
+
+def test_test_request_builds_binary_form_body():
+    request = MoinTestRequest(
+        method='POST',
+        form_data=MultiDict([('name', 'Jürgen'), ('tag', 'one')]),
+    )
+
+    assert request.form['name'] == 'Jürgen'
+    assert request.form.getlist('tag') == ['one']
+
+
+def test_request_parses_basic_authorization():
+    credentials = b64encode('Jürgen:päss'.encode('utf-8')).decode('ascii')
+    request = MoinTestRequest(environ_overrides={
+        'HTTP_AUTHORIZATION': 'Basic ' + credentials,
+    })
+
+    assert request.authorization.username == 'Jürgen'
+    assert request.authorization.password == 'päss'
+
+
+def test_surge_protection_sets_retry_after():
+    exception = SurgeProtection(retry_after=17)
+    client = Client(exception, Response)
+
+    response = client.get('/')
+
+    assert response.status_code == 503
+    assert response.headers['Retry-After'] == '17'
+
+
+def test_static_middleware_serves_configured_file(tmp_path):
+    static_file = tmp_path / 'hello.txt'
+    static_file.write_text('Hello', encoding='utf-8')
+
+    def fallback(environ, start_response):
+        return Response('fallback', status=404)(environ, start_response)
+
+    application = make_static_serving_app(
+        fallback, {'/assets': str(tmp_path)})
+    client = Client(application, Response)
+
+    response = client.get('/assets/hello.txt')
+
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == 'Hello'
+
+
+def test_path_info_fixer_recovers_raw_utf8_path():
+    captured = {}
+
+    def application(environ, start_response):
+        captured.update(environ)
+        start_response('204 No Content', [])
+        return []
+
+    middleware = PathInfoFromRequestUriFix(application)
+    environ = MoinTestRequest().environ
+    environ['SCRIPT_NAME'] = '/moin'
+    environ['REQUEST_URI'] = '/moin/wiki/%C3%84rger?do=show'
+
+    list(middleware(environ, lambda status, headers: None))
+
+    assert captured['PATH_INFO'].encode('latin-1').decode('utf-8') == (
+        '/wiki/Ärger')
+
+
+def test_werkzeug_imports_are_isolated_to_http_facade():
+    package_root = Path(__file__).resolve().parents[3] / 'MoinMoin'
+    facade = package_root / 'web' / 'http.py'
+    offenders = []
+
+    for source_path in package_root.rglob('*.py'):
+        if source_path == facade:
+            continue
+        tree = ast.parse(source_path.read_text(encoding='utf-8'))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                names = [node.module or '']
+            else:
+                continue
+            if any(name == 'werkzeug' or name.startswith('werkzeug.')
+                   for name in names):
+                offenders.append(str(source_path.relative_to(package_root)))
+
+    assert offenders == []

--- a/tests/web/_tests/test_session.py
+++ b/tests/web/_tests/test_session.py
@@ -1,0 +1,74 @@
+"""
+MoinMoin server-side session tests.
+
+@license: GNU GPL, see COPYING for details.
+"""
+
+import pickle
+
+import pytest
+
+from MoinMoin.web.session import FilesystemSessionStore, MoinSession
+
+
+def test_session_tracks_direct_changes():
+    session = MoinSession({'name': 'Alice'}, 'a' * 40)
+
+    assert not session.should_save
+
+    session['name'] = 'Bob'
+
+    assert session.should_save
+
+
+def test_filesystem_store_reads_existing_pickle_format(tmp_path):
+    sid = 'a' * 40
+    session_file = tmp_path / sid
+    session_file.write_bytes(
+        pickle.dumps({'user.id': '42'}, pickle.HIGHEST_PROTOCOL))
+    store = FilesystemSessionStore(
+        path=str(tmp_path), filename_template='%s', mode=0o600)
+
+    session = store.get(sid)
+
+    assert session == {'user.id': '42'}
+    assert session.sid == sid
+    assert not session.new
+    assert not session.modified
+
+
+def test_filesystem_store_roundtrip_and_list(tmp_path):
+    store = FilesystemSessionStore(
+        path=str(tmp_path), filename_template='%s', mode=0o600)
+    session = store.new()
+    session['trail'] = ['FrontPage']
+
+    store.save(session)
+
+    restored = store.get(session.sid)
+    assert restored == {'trail': ['FrontPage']}
+    assert session.sid in store.list()
+    assert (tmp_path / session.sid).stat().st_mode & 0o777 == 0o600
+
+    store.delete(restored)
+    assert not (tmp_path / session.sid).exists()
+
+
+def test_invalid_session_id_gets_replaced(tmp_path):
+    store = FilesystemSessionStore(
+        path=str(tmp_path), filename_template='%s')
+
+    session = store.get('../not-a-session')
+
+    assert session.new
+    assert session.sid != '../not-a-session'
+    assert store.is_valid_key(session.sid)
+
+
+def test_invalid_session_id_cannot_be_saved(tmp_path):
+    store = FilesystemSessionStore(
+        path=str(tmp_path), filename_template='%s')
+    session = MoinSession({}, '../not-a-session')
+
+    with pytest.raises(ValueError):
+        store.save(session)

--- a/wiki/server/moin.fcgi
+++ b/wiki/server/moin.fcgi
@@ -63,7 +63,7 @@ else:
 fix_apache_win32 = False  # <-- adapt here as needed
 
 if fix_apache_win32:
-    from werkzeug.contrib.fixers import PathInfoFromRequestUriFix
+    from MoinMoin.web.http import PathInfoFromRequestUriFix
     application = PathInfoFromRequestUriFix(application)
 
 
@@ -78,4 +78,3 @@ except ImportError:
     from MoinMoin.web._fallback_cgi import WSGIServer
 
 WSGIServer(application).run()
-


### PR DESCRIPTION
## Summary
- require Python 3.10+ and upgrade Werkzeug to 3.1.8
- route application HTTP imports through a new MoinMoin.web.http facade
- replace removed Werkzeug URL helpers with compatible urllib.parse implementations
- remove private Werkzeug logger usage and update request, exception, static, auth, and FastCGI paths
- replace secure-cookie with an internal atomic filesystem session store while preserving existing pickle files and 40-character session IDs
- add Python 3.10 to the compatibility matrix and cover URL, multipart, Basic Auth, static serving, exceptions, raw URI handling, and sessions

## Verification
- clean installs on Python 3.10.19, 3.13, and 3.14 resolve Werkzeug 3.1.8 with no secure-cookie, WebOb, or multipart replacement dependencies
- compatibility suite on each version: 98 passed, 2 skipped, 12 xfailed
- strict SyntaxWarning compilation passes on Python 3.10, 3.13, and 3.14
- full Python 3.13 suite: 479 passed; the existing 4 failures and 56 missing-Xapian errors are unchanged
