### PR TITLE
Fix remaining P1 runtime issues

### DIFF
--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -55,9 +55,13 @@ jobs:
             tests/_tests/test_packages.py \
             tests/macro/_tests/test_Action.py \
             tests/_tests/test_account_inactive.py \
+            tests/_tests/test_cli_show.py \
             tests/web/_tests/test_http.py \
             tests/web/_tests/test_session.py \
             tests/web/_tests/test_contexts.py \
+            tests/converter/_tests/test_text_html_text_moin_wiki.py::TestConvertBlockRepeatable::testPreSuccess6 \
+            tests/converter/_tests/test_text_html_text_moin_wiki.py::TestConvertBlockRepeatable::testPreSuccess8 \
+            tests/converter/_tests/test_text_html_text_moin_wiki.py::TestConvertBlockRepeatable::testPreSuccess12 \
             tests/_tests/test_Page.py::TestPage::testRequestCompatibilityAlias \
             tests/action/_tests/test_cache.py \
             tests/parser/_tests/test_unicode.py \

--- a/MoinMoin/config/__init__.py
+++ b/MoinMoin/config/__init__.py
@@ -48,6 +48,9 @@ use_threads = False
 # benefit for the user. IMPORTANT: use only lowercase 'utf-8'!
 charset = 'utf-8'
 
+# Maximum memory used for non-file form fields before rejecting a request.
+form_max_memory_size = 10 * 1024 * 1024
+
 # Regex to find lower->upper transitions (word boundaries in WikiNames), used by split_title
 split_regex = re.compile('([%s])([%s])' % (chars_lower, chars_upper), re.UNICODE)
 

--- a/MoinMoin/config/multiconfig.py
+++ b/MoinMoin/config/multiconfig.py
@@ -909,6 +909,9 @@ options_no_group_name = {
                             "Surge protection tries to deny clients causing too much load/traffic, see HelpOnConfiguration/SurgeProtection."),
                            ('surge_lockout_time', 3600, "time [s] someone gets locked out when ignoring the warnings"),
 
+                           ('form_max_memory_size', config.form_max_memory_size,
+                            "maximum memory used for non-file form fields before rejecting the request [bytes]"),
+
                            ('textchas', None,
                             "Spam protection setup using site-specific questions/answers, see HelpOnSpam."),
                            ('textchas_disabled_group', None,

--- a/MoinMoin/converter/text_html_text_moin_wiki.py
+++ b/MoinMoin/converter/text_html_text_moin_wiki.py
@@ -958,8 +958,8 @@ class convert_tree(visitor):
             for i in node.childNodes:
                 if i.nodeType == Node.TEXT_NODE:
                     # get longest pre tag({{{ or }}}) from content
-                    delimiters.extend(re.compile("((?u){+)").findall(i.data))
-                    delimiters.extend(re.compile("((?u)}+)").findall(i.data))
+                    delimiters.extend(re.compile(r"(\{+)").findall(i.data))
+                    delimiters.extend(re.compile(r"(\}+)").findall(i.data))
                     # when first line is empty, start iteration second line of i.data
                     data_lines = i.data.rstrip().split('\n')
                     if data_lines[0].strip() == '':

--- a/MoinMoin/script/cli/show.py
+++ b/MoinMoin/script/cli/show.py
@@ -6,7 +6,6 @@ MoinMoin - cli show script
 """
 
 from MoinMoin.script import MoinScript
-from MoinMoin.wsgiapp import run
 
 
 class PluginScript(MoinScript):
@@ -28,4 +27,4 @@ General syntax: moin [options] cli show
 
     def mainloop(self):
         self.init_request()
-        run(self.request)
+        self.request.run()

--- a/MoinMoin/web/contexts.py
+++ b/MoinMoin/web/contexts.py
@@ -642,8 +642,8 @@ class ScriptContext(AllContext):
 
     def write(self, *data):
         for d in data:
-            if isinstance(d, str):
-                d = d.encode(config.charset)
-            else:
+            if isinstance(d, bytes):
+                d = d.decode(config.charset, 'replace')
+            elif not isinstance(d, str):
                 d = str(d)
             sys.stdout.write(d)

--- a/MoinMoin/web/request.py
+++ b/MoinMoin/web/request.py
@@ -154,6 +154,11 @@ class Request(RequestBase):
     # get rid of some inherited descriptors
     headers = None
 
+    @property
+    def max_form_memory_size(self):
+        cfg = self.environ.get('moin.cfg')
+        return getattr(cfg, 'form_max_memory_size', config.form_max_memory_size)
+
     def __init__(self, environ, populate_request=True, shallow=False, given_config=None):
         super().__init__(environ, populate_request, shallow)
         self.href = Href(self.script_root or '/', self.charset)

--- a/tests/_tests/test_cli_show.py
+++ b/tests/_tests/test_cli_show.py
@@ -1,0 +1,48 @@
+"""
+MoinMoin CLI show compatibility tests.
+
+@license: GNU GPL, see COPYING for details.
+"""
+
+import importlib
+from io import StringIO
+
+
+def test_cli_show_module_imports():
+    module = importlib.import_module('MoinMoin.script.cli.show')
+
+    assert module.PluginScript
+
+
+def test_cli_show_runs_script_context():
+    module = importlib.import_module('MoinMoin.script.cli.show')
+    script = module.PluginScript(argv=[], def_values=None)
+    calls = []
+
+    class Request:
+        def run(self):
+            calls.append('run')
+
+    def init_request():
+        script.request = Request()
+
+    script.init_request = init_request
+    script.mainloop()
+
+    assert calls == ['run']
+
+
+def test_script_context_write_uses_text_stdout(monkeypatch):
+    from MoinMoin import i18n
+    from MoinMoin.web.contexts import ScriptContext
+
+    output = StringIO()
+    context = object.__new__(ScriptContext)
+    context.environ = {}
+    context.lang = 'en'
+    monkeypatch.setattr('sys.stdout', output)
+    monkeypatch.setattr(i18n, 'userLanguage', lambda request: 'en')
+
+    context.write('Jürgen', b' bytes', 42)
+
+    assert output.getvalue() == 'Jürgen bytes42'

--- a/tests/web/_tests/test_http.py
+++ b/tests/web/_tests/test_http.py
@@ -7,13 +7,18 @@ MoinMoin HTTP facade compatibility tests.
 import ast
 from base64 import b64encode
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
+
+from MoinMoin.config.multiconfig import DefaultConfig
 from MoinMoin.web.exceptions import SurgeProtection
 from MoinMoin.web.http import (
     Client,
     MultiDict,
     PathInfoFromRequestUriFix,
     Response,
+    exceptions,
     url_decode,
     url_encode,
     url_quote,
@@ -59,6 +64,28 @@ def test_test_request_builds_binary_form_body():
 
     assert request.form['name'] == 'Jürgen'
     assert request.form.getlist('tag') == ['one']
+
+
+def test_request_defaults_to_ten_megabyte_form_memory_limit():
+    request = MoinTestRequest()
+
+    assert DefaultConfig.form_max_memory_size == 10 * 1024 * 1024
+    assert request.max_form_memory_size == 10 * 1024 * 1024
+
+
+def test_request_accepts_forms_larger_than_werkzeug_legacy_default():
+    value = 'x' * 501_000
+    request = MoinTestRequest(method='POST', form_data={'text': value})
+
+    assert request.form['text'] == value
+
+
+def test_request_uses_loaded_wiki_form_memory_limit():
+    request = MoinTestRequest(method='POST', form_data={'text': 'x' * 2_000})
+    request.environ['moin.cfg'] = SimpleNamespace(form_max_memory_size=1_000)
+
+    with pytest.raises(exceptions.RequestEntityTooLarge):
+        request.form
 
 
 def test_request_parses_basic_authorization():


### PR DESCRIPTION
## Summary
- fix Python 3 regex handling in the HTML-to-wiki converter
- add a configurable `form_max_memory_size` with a secure 10 MiB default
- restore `moin cli show` using `ScriptContext.run()` and text-safe stdout handling
- add regression coverage to the Python 3.10/3.13/3.14 compatibility workflow

## Verification
- Python 3.10 targeted regressions: 18 passed
- Python 3.13 targeted regressions: 18 passed
- Python 3.14 targeted regressions: 18 passed
- Python 3.14 compatibility suite: 138 passed, 1 skipped, 1 existing xfail
- Python 3.14 full `tests` suite: 492 passed; remaining 1 failure is the existing language-search state leak and 56 errors require optional Xapian bindings
- strict `SyntaxWarning` compilation passed on Python 3.10, 3.13, and 3.14
- `moin cli show` was exercised against the test wiki and rendered a complete page