### PR TITLE
Fix remaining P2 Python compatibility issues

### DIFF
--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -55,8 +55,13 @@ jobs:
             tests/_tests/test_packages.py \
             tests/macro/_tests/test_Action.py \
             tests/_tests/test_account_inactive.py \
+            tests/_tests/test_check_i18n.py \
             tests/_tests/test_cli_show.py \
+            tests/_tests/test_example_config_encoding.py \
+            tests/_tests/test_gugiel.py \
+            tests/_tests/test_print_stats.py \
             tests/web/_tests/test_http.py \
+            tests/web/_tests/test_profile.py \
             tests/web/_tests/test_session.py \
             tests/web/_tests/test_contexts.py \
             tests/converter/_tests/test_text_html_text_moin_wiki.py::TestConvertBlockRepeatable::testPreSuccess6 \

--- a/MoinMoin/i18n/tools/check_i18n.py
+++ b/MoinMoin/i18n/tools/check_i18n.py
@@ -15,8 +15,7 @@ names.
 The script will run from the moin root directory, where the MoinMoin
 package lives, or from MoinMoin/i18n where this script lives.
 
-TextFinder class based on code by Seo Sanghyeon and the python compiler
-package.
+TextFinder class based on code by Seo Sanghyeon.
 
 TODO: fix it for the changed i18n stuff of moin 1.6
 
@@ -34,14 +33,17 @@ output_encoding = 'utf-8'
 blacklist_files = []
 blacklist_langs = []
 
-import sys, os, compiler
-from compiler.ast import Name, Const, CallFunc, Getattr
+import ast
+import os
+import sys
+import tokenize
 
-class TextFinder:
+
+class TextFinder(ast.NodeVisitor):
     """ Walk through AST tree and collect text from gettext calls
 
     Find all calls to gettext function in the source tree and collect
-    the texts in a dict. Use compiler to create an abstract syntax tree
+    the texts in a dict. Use ast to create an abstract syntax tree
     from each source file, then find the nodes for gettext function
     call, and get the text from the call.
 
@@ -77,50 +79,33 @@ class TextFinder:
     def visitModule(self, node):
         """ Start the search from the top node of a module
 
-        This is the entry point into the search. When compiler.walk is
-        called it calls this method with the module node.
+        This is the entry point into the search.
 
         This is the place to initialize module specific data.
         """
-        self._visited = {}  # init node cache - we will visit each node once
         self._lineno = 'NA' # init line number
 
-        # Start walking in the module node
-        self.walk(node)
+        self.visit(node)
 
-    def walk(self, node):
-        """ Walk through all nodes """
-        if node in self._visited:
-            # We visited this node already
-            return
-
-        self._visited[node] = 1
-        if not self.parseNode(node):
-            for child in node.getChildNodes():
-                self.walk(child)
-
-    def parseNode(self, node):
+    def visit_Call(self, node):
         """ Parse function call nodes and collect text """
 
-        # Get the current line number. Since not all nodes have a line number
-        # we save the last line number - it should be close to the gettext call
-        if node.lineno is not None:
-            self._lineno = node.lineno
+        self._lineno = node.lineno
+        function = node.func
+        is_gettext_call = (
+            isinstance(function, ast.Name) and function.id == self._name
+        ) or (
+            isinstance(function, ast.Attribute) and function.attr == self._name
+        )
+        if not is_gettext_call or not node.args:
+            self.generic_visit(node)
+            return
 
-        if node.__class__ == CallFunc and node.args:
-            child = node.node
-            klass = child.__class__
-            if (# Standard call _('text')
-                (klass == Name and child.name == self._name) or
-                # A call to an object attribute: object._('text')
-                (klass == Getattr and child.attrname == self._name)):
-                if node.args[0].__class__ == Const:
-                    # Good call with a constant _('text')
-                    self.addText(node.args[0].value)
-                else:
-                    self.addBadCall(node)
-                return 1
-        return 0
+        argument = node.args[0]
+        if isinstance(argument, ast.Constant):
+            self.addText(argument.value)
+        else:
+            self.addBadCall(node)
 
     def addText(self, text):
         """ Add text to dictionary and count found texts.
@@ -172,8 +157,9 @@ class TextFinder:
 
 def visit(path, visitor):
     visitor.setFilename(path)
-    tree = compiler.parseFile(path)
-    compiler.walk(tree, visitor)
+    with tokenize.open(path) as source_file:
+        tree = ast.parse(source_file.read(), filename=os.fspath(path))
+    visitor.visitModule(tree)
 
 
 # MoinMoin specific stuff follows
@@ -370,5 +356,3 @@ userprefs options, from Icon titles etc.!
 """)
             for text in report[lang].unused():
                 print(" 1. `%r`" % text)
-
-

--- a/MoinMoin/script/old/print_stats.py
+++ b/MoinMoin/script/old/print_stats.py
@@ -1,34 +1,32 @@
 #!/usr/bin/env python
 
 """
-    MoinMoin - Print statistics gathered by hotshot profiler
+    MoinMoin - Print statistics gathered by cProfile
 
     Usage:
         print_stats.py statsfile
 
     Typical usage:
-     1. Edit moin.py and activate the hotshot profiler, set profile file name
+     1. Configure the cProfile middleware and set the profile file name
      2. Run moin.py
      3. Do some request, with a browser, script or ab
      4. Stop moin.py
      5. Run this tool: print_stats.py moin.prof
-
-    Currently CGI and twisted also have a hotshot profiler integration.
 
     @copyright: 2005 by Thomas Waldmann (MoinMoin:ThomasWaldmann)
     @license: GNU GPL, see COPYING for details.
 """
 
 def run():
+    import pstats
     import sys
-    from hotshot import stats
 
     if len(sys.argv) != 2:
         print(__doc__)
         sys.exit()
 
     # Load and print stats
-    s = stats.load(sys.argv[1])
+    s = pstats.Stats(sys.argv[1])
     s.strip_dirs()
     s.sort_stats('cumulative', 'time', 'calls')
     s.print_stats(40)
@@ -36,4 +34,3 @@ def run():
 
 if __name__ == "__main__":
     run()
-

--- a/MoinMoin/web/profile.py
+++ b/MoinMoin/web/profile.py
@@ -43,7 +43,7 @@ class ProfilerMiddleware:
         url = get_current_url(environ)
         logging.debug("Profiling call for '%s %s'", method, url)
         try:
-            res = self.run_profile(self.app, (environ, start_response))
+            res = self.run_profile(self.app, environ, start_response)
         except Exception as e:
             logging.exception("Exception while profiling '%s %s'", method, url)
             raise
@@ -78,17 +78,8 @@ class CProfileMiddleware(ProfilerMiddleware):
         self._profile.dump_stats(self._filename)
 
 
-class HotshotMiddleware(ProfilerMiddleware):
-    """ A profiler based on the more recent hotshot module from the stdlib. """
-
-    def __init__(self, app, *args, **kwargs):
-        super(HotshotMiddleware, self).__init__(app)
-        import hotshot
-        self._profile = hotshot.Profile(*args, **kwargs)
-        self.run_profile = self._profile.runcall
-
-    def shutdown(self):
-        self._profile.close()
+class HotshotMiddleware(CProfileMiddleware):
+    """Compatibility name for the removed stdlib hotshot profiler."""
 
 
 class PycallgraphMiddleware(ProfilerMiddleware):

--- a/MoinMoin/web/static/htdocs/gugiel/gugiel.py
+++ b/MoinMoin/web/static/htdocs/gugiel/gugiel.py
@@ -6,6 +6,8 @@
     @license: GNU GPL, see COPYING for details.
 """
 
+from io import StringIO
+
 from MoinMoin.theme import ThemeBase
 from MoinMoin import wikiutil
 from MoinMoin.Page import Page
@@ -319,8 +321,7 @@ class Theme(ThemeBase):
         page = Page(request, sidebar)
         if not page.exists():
             return u""
-        import StringIO
-        buff = StringIO.StringIO()
+        buff = StringIO()
         request.redirect(buff)
         try:
             page.send_page(content_only=1, content_id="sidebar")
@@ -337,4 +338,3 @@ def execute(request):
     @return: Theme object
     """
     return Theme(request)
-

--- a/tests/_tests/test_check_i18n.py
+++ b/tests/_tests/test_check_i18n.py
@@ -1,0 +1,29 @@
+"""
+Tests for the i18n source checker.
+
+@license: GNU GPL, see COPYING for details.
+"""
+
+import importlib
+
+
+def test_text_finder_uses_python_ast(tmp_path, capsys):
+    check_i18n = importlib.import_module('MoinMoin.i18n.tools.check_i18n')
+    source = tmp_path / 'messages.py'
+    source.write_text(
+        "_('direct')\n"
+        "translator._('attribute')\n"
+        "_('dynamic ' + value)\n",
+        encoding='utf-8',
+    )
+    finder = check_i18n.TextFinder()
+
+    check_i18n.visit(source, finder)
+
+    assert finder.dictionary() == {
+        'direct': {source: [1]},
+        'attribute': {source: [2]},
+    }
+    assert finder.found() == 2
+    assert finder.bad() == 1
+    assert 'non-constant _ call' in capsys.readouterr().out

--- a/tests/_tests/test_example_config_encoding.py
+++ b/tests/_tests/test_example_config_encoding.py
@@ -1,0 +1,27 @@
+"""
+Tests for example configuration source encodings.
+
+@license: GNU GPL, see COPYING for details.
+"""
+
+import ast
+from pathlib import Path
+import tokenize
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize('relative_path', [
+    'wiki/config/wikiconfig.py',
+    'wiki/config/wikifarm/farmconfig.py',
+])
+def test_example_config_has_a_valid_source_encoding(relative_path):
+    path = REPOSITORY_ROOT / relative_path
+
+    with tokenize.open(path) as source_file:
+        source = source_file.read()
+
+    ast.parse(source, filename=str(path))

--- a/tests/_tests/test_gugiel.py
+++ b/tests/_tests/test_gugiel.py
@@ -1,0 +1,56 @@
+"""
+Tests for the legacy Gugiel theme.
+
+@license: GNU GPL, see COPYING for details.
+"""
+
+import importlib.util
+from pathlib import Path
+
+
+GUGIEL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / 'MoinMoin/web/static/htdocs/gugiel/gugiel.py'
+)
+
+
+def load_gugiel():
+    spec = importlib.util.spec_from_file_location('moin_test_gugiel', GUGIEL_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sidebar_captures_rendered_page(monkeypatch):
+    gugiel = load_gugiel()
+
+    class Request:
+        def __init__(self):
+            self.write = None
+            self.getText = lambda text: text
+
+        def getPragma(self, name):
+            return None
+
+        def redirect(self, output=None):
+            self.write = output.write if output is not None else None
+
+    class SidebarPage:
+        def __init__(self, request, name):
+            self.request = request
+
+        def exists(self):
+            return True
+
+        def send_page(self, **kwargs):
+            self.request.write('sidebar content')
+
+    request = Request()
+    theme = object.__new__(gugiel.Theme)
+    theme.request = request
+    monkeypatch.setattr(gugiel, 'Page', SidebarPage)
+
+    assert theme.sidebar({}) == (
+        '<div class="sidebar">sidebar content</div>'
+    )
+    assert request.write is None

--- a/tests/_tests/test_print_stats.py
+++ b/tests/_tests/test_print_stats.py
@@ -1,0 +1,23 @@
+"""
+Tests for the legacy profile statistics tool.
+
+@license: GNU GPL, see COPYING for details.
+"""
+
+import cProfile
+import sys
+
+
+def test_print_stats_reads_cprofile_output(tmp_path, monkeypatch, capsys):
+    from MoinMoin.script.old import print_stats
+
+    stats_path = tmp_path / 'profile.stats'
+    profiler = cProfile.Profile()
+    profiler.runcall(sum, range(5))
+    profiler.dump_stats(str(stats_path))
+
+    monkeypatch.setattr(sys, 'argv', ['print_stats.py', str(stats_path)])
+
+    print_stats.run()
+
+    assert 'function calls' in capsys.readouterr().out

--- a/tests/web/_tests/test_profile.py
+++ b/tests/web/_tests/test_profile.py
@@ -1,0 +1,30 @@
+"""
+Tests for WSGI profiling middleware.
+
+@license: GNU GPL, see COPYING for details.
+"""
+
+import pstats
+
+import pytest
+
+from MoinMoin.web.http import Client, Response
+from MoinMoin.web.profile import CProfileMiddleware, HotshotMiddleware
+
+
+@pytest.mark.parametrize('middleware_class', [
+    CProfileMiddleware,
+    HotshotMiddleware,
+])
+def test_profiler_runs_wsgi_app_and_writes_stats(tmp_path, middleware_class):
+    def application(environ, start_response):
+        start_response('200 OK', [('Content-Type', 'text/plain')])
+        return [b'profiled']
+
+    stats_path = tmp_path / (middleware_class.__name__ + '.stats')
+    middleware = middleware_class(application, str(stats_path))
+    response = Client(middleware, Response).get('/')
+    middleware.shutdown()
+
+    assert response.get_data() == b'profiled'
+    assert pstats.Stats(str(stats_path)).total_calls > 0

--- a/wiki/config/wikiconfig.py
+++ b/wiki/config/wikiconfig.py
@@ -1,3 +1,4 @@
+# -*- coding: iso-8859-1 -*-
 
 # IMPORTANT! This encoding (charset) setting MUST be correct! If you live in a
 # western country and you don't know that you use utf-8, you probably want to

--- a/wiki/config/wikifarm/farmconfig.py
+++ b/wiki/config/wikifarm/farmconfig.py
@@ -1,3 +1,4 @@
+# -*- coding: iso-8859-1 -*-
 
 # IMPORTANT! This encoding (charset) setting MUST be correct! If you live in a
 # western country and you don't know that you use utf-8, you probably want to


### PR DESCRIPTION
## Summary
- replace the removed compiler AST API in check_i18n with the standard ast module
- replace hotshot profiling and stats reading with cProfile/pstats while preserving HotshotMiddleware
- migrate the Gugiel theme to io.StringIO
- add valid source encoding declarations to the Latin-1 example configurations
- cover these paths in the Python 3.10, 3.13, and 3.14 compatibility workflow

## Verification
- targeted P2 tests: 7 passed on Python 3.10, 3.13, and 3.14
- compatibility workflow set: 145 passed, 1 skipped, 1 xfailed on Python 3.14
- strict SyntaxWarning compilation passed on Python 3.10, 3.13, and 3.14
- full tests: 499 passed, 1 existing order-dependent search failure, 56 existing errors due to missing Xapian bindings
- pip check passed on all three Python versions