### PR TITLE
Fix fullsearch context shadowing

### DIFF
--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -69,6 +69,7 @@ jobs:
             tests/converter/_tests/test_text_html_text_moin_wiki.py::TestConvertBlockRepeatable::testPreSuccess12 \
             tests/_tests/test_Page.py::TestPage::testRequestCompatibilityAlias \
             tests/action/_tests/test_cache.py \
+            tests/action/_tests/test_fullsearch.py \
             tests/parser/_tests/test_unicode.py \
             tests/search/_tests/test_search.py::TestMoinSearch \
             tests/datastruct/backends/_tests/test_config_groups.py \

--- a/MoinMoin/action/fullsearch.py
+++ b/MoinMoin/action/fullsearch.py
@@ -72,13 +72,13 @@ def execute(pagename, context, fieldname='value', titlesearch=0, statistic=0):
 
     form = context.request.values
 
-    # context is relevant only for full search
+    # Result context is relevant only for full search.
     if titlesearch:
-        context = 0
+        context_lines = 0
     elif advancedsearch:
-        context = 180  # XXX: hardcoded context count for advancedsearch
+        context_lines = 180  # XXX: hardcoded context count for advancedsearch
     else:
-        context = int(form.get('context', 0))
+        context_lines = int(form.get('context', 0))
 
     # Get other form parameters
     needle = form.get(fieldname, '')
@@ -273,9 +273,9 @@ def execute(pagename, context, fieldname='value', titlesearch=0, statistic=0):
 
     # Then search results
     info = not titlesearch
-    if context:
+    if context_lines:
         output = results.pageListWithContext(context, context.formatter,
-                                             info=info, context=context, hitsFrom=hitsFrom, hitsInfo=1,
+                                             info=info, context=context_lines, hitsFrom=hitsFrom, hitsInfo=1,
                                              highlight_titles=highlight_titles,
                                              highlight_pages=highlight_pages)
     else:

--- a/tests/action/_tests/test_fullsearch.py
+++ b/tests/action/_tests/test_fullsearch.py
@@ -1,0 +1,79 @@
+"""
+MoinMoin - fullsearch action tests
+
+@license: GNU GPL, see COPYING for details.
+"""
+
+import pytest
+
+from MoinMoin import search
+from MoinMoin.Page import Page
+from MoinMoin.action import fullsearch
+from MoinMoin.web.contexts import AllContext
+from MoinMoin.web.request import TestRequest as MoinTestRequest
+
+
+@pytest.mark.parametrize('query_string, expected_sort', [
+    ('value=Search&titlesearch=Titles&context=180', 'page_name'),
+    ('value=Search&fullsearch=Text&context=180', 'weight'),
+])
+def test_execute_preserves_request_context(
+        req, monkeypatch, query_string, expected_sort):
+    request = MoinTestRequest(path='/FrontPage', query_string=query_string)
+    request.given_config = req.cfg.__class__
+    context = AllContext(request)
+    search_call = {}
+
+    class SearchCalled(Exception):
+        pass
+
+    def record_search(search_context, query, sort, mtime, historysearch):
+        search_call['context'] = search_context
+        search_call['sort'] = sort
+        raise SearchCalled
+
+    monkeypatch.setattr(search, 'searchPages', record_search)
+
+    with pytest.raises(SearchCalled):
+        fullsearch.execute('FrontPage', context)
+
+    assert search_call['context'] is context
+    assert search_call['sort'] == expected_sort
+
+
+def test_execute_passes_context_lines_to_result_renderer(req, monkeypatch):
+    request = MoinTestRequest(
+        path='/FrontPage',
+        query_string='value=Search&fullsearch=Text&context=180',
+    )
+    request.given_config = req.cfg.__class__
+    context = AllContext(request)
+    context.page = Page(context, 'FrontPage')
+    render_call = {}
+
+    class ResultsRendered(Exception):
+        pass
+
+    class SearchResults:
+        hits = [object()]
+
+        def stats(self, request_context, formatter, hits_from):
+            return ''
+
+        def pageListWithContext(
+                self, request_context, formatter, **kwargs):
+            render_call['context'] = request_context
+            render_call['context_lines'] = kwargs['context']
+            raise ResultsRendered
+
+    monkeypatch.setattr(search, 'searchPages', lambda *args: SearchResults())
+    monkeypatch.setattr(context, 'write', lambda *args: None)
+    monkeypatch.setattr(context, 'setContentLanguage', lambda lang: None)
+    monkeypatch.setattr(
+        context.theme, 'send_title', lambda *args, **kwargs: None)
+
+    with pytest.raises(ResultsRendered):
+        fullsearch.execute('FrontPage', context)
+
+    assert render_call['context'] is context
+    assert render_call['context_lines'] == 180


### PR DESCRIPTION
## Summary
- keep the request context separate from the numeric search-result context length
- pass `context_lines` to `pageListWithContext` without replacing the request object
- add regression coverage for title search, full-text search, and result rendering
- include the new test in the Python compatibility workflow

## Testing
- `pytest -q -p no:cacheprovider tests/action/_tests/test_fullsearch.py tests/search/_tests/test_search.py::TestMoinSearch` (`30 passed, 1 xfailed`)
- `python -m compileall -q -f MoinMoin/action/fullsearch.py tests/action/_tests/test_fullsearch.py`
- `git diff --check`