### PR TITLE
Publish Docker image to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,14 +11,15 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: docker-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  REGISTRY: docker.io
-  IMAGE_NAME: ch3n2k/py3moin
+  DOCKERHUB_IMAGE: docker.io/ch3n2k/py3moin
+  GHCR_IMAGE: ghcr.io/${{ github.repository }}
 
 jobs:
   docker:
@@ -36,15 +37,25 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: docker.io
           username: ch3n2k
           password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate image metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.GHCR_IMAGE }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,56 @@ MoinMoin is a wiki engine - a software you can use to run your own wiki site.
 
 This is a fork of MoinMoin 1.x that runs on Python 3.10 and newer.
 
+Docker
+======
+
+The latest image is published to the GitHub Container Registry. Pull it,
+create a persistent instance directory, and copy the default wiki files into
+that directory:
+
+.. code-block:: console
+
+   $ docker pull ghcr.io/zhongkechen/py3moin:latest
+   $ mkdir py3moin-data
+   $ docker run --rm --user "$(id -u):$(id -g)" \
+       -v "$PWD/py3moin-data:/data" \
+       ghcr.io/zhongkechen/py3moin:latest \
+       sh -c 'cp -r /app/wiki/data /data/ &&
+              cp /app/wiki/config/wikiconfig.py /app/wiki/server/moin.wsgi /data/ &&
+              tar -xf /app/wiki/underlay.tar -C /data'
+
+Create ``py3moin-data/uwsgi.ini`` with the following contents:
+
+.. code-block:: ini
+
+   [uwsgi]
+   http-socket = 0.0.0.0:8080
+   plugin = python3
+   chdir = /data
+   wsgi-file = /data/moin.wsgi
+   master = true
+   processes = 2
+   threads = 2
+   need-app = true
+
+Start the wiki:
+
+.. code-block:: console
+
+   $ docker run -d \
+       --name py3moin \
+       --restart unless-stopped \
+       -p 8080:8080 \
+       -v "$PWD/py3moin-data:/data" \
+       ghcr.io/zhongkechen/py3moin:latest
+
+Open http://localhost:8080/ in a browser. Wiki content and configuration are
+stored in ``py3moin-data``; back up this directory and edit
+``py3moin-data/wikiconfig.py`` to configure the instance.
+
+The same image is also available from Docker Hub as
+``docker.io/ch3n2k/py3moin:latest``.
+
 Documentation
 =============
 


### PR DESCRIPTION
## Summary

- publish Docker images to GHCR in addition to Docker Hub
- authenticate with the built-in GitHub token and grant package write permission
- document Docker installation, persistent data initialization, and startup

## Validation

- parsed the workflow as YAML
- checked the documented bootstrap shell syntax and source paths
- ran git diff --check